### PR TITLE
ci: create GitHub releases on tag publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -131,3 +134,12 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: 98f7f5df215cccc750e75aac4bcf76fe
+
+  create-github-release:
+    needs: [publish-npm, deploy-relay, deploy-site]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
Adds a final job to the tag-triggered release workflow that creates an actual GitHub Release after npm publish, relay deploy, and site deploy succeed. Also adds contents: write permission for release creation.