### PR TITLE
feat: add doctor command and local diagnostics logging

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,11 +13,30 @@ import { join } from "./commands/join.js";
 import { status } from "./commands/status.js";
 import { start } from "./commands/start.js";
 import { stop } from "./commands/stop.js";
+import { doctor } from "./commands/doctor.js";
 import { update } from "./commands/update.js";
+import { createLogger } from "./log.js";
 import { VERSION } from "./version.js";
 import * as ui from "./ui.js";
 
 const program = new Command();
+const logger = createLogger("cli");
+
+async function runCommand(name: string, fn: () => Promise<void>): Promise<void> {
+  logger.info("command start", { command: name });
+  try {
+    await fn();
+    logger.info("command success", { command: name });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error("command failed", "BSYNC_COMMAND_FAILED", {
+      command: name,
+      error: message,
+    });
+    ui.error(message);
+    process.exit(1);
+  }
+}
 
 program
   .name("botsync")
@@ -27,85 +46,42 @@ program
 program
   .command("init")
   .description("Initialize botsync and start syncing. Prints a passphrase for pairing.")
-  .action(async () => {
-    try {
-      await init();
-    } catch (err) {
-      ui.error(err instanceof Error ? err.message : String(err));
-      process.exit(1);
-    }
-  });
+  .action(async () => runCommand("init", init));
 
 program
   .command("invite")
   .description("Generate a new pairing code to add another machine to this network.")
-  .action(async () => {
-    try {
-      await invite();
-    } catch (err) {
-      ui.error(err instanceof Error ? err.message : String(err));
-      process.exit(1);
-    }
-  });
+  .action(async () => runCommand("invite", invite));
 
 program
   .command("join <passphrase>")
   .description("Connect to another botsync instance using a passphrase.")
-  .action(async (passphrase: string) => {
-    try {
-      await join(passphrase);
-    } catch (err) {
-      ui.error(err instanceof Error ? err.message : String(err));
-      process.exit(1);
-    }
-  });
+  .action(async (passphrase: string) => runCommand("join", () => join(passphrase)));
 
 program
   .command("status")
   .description("Show sync status — peers, folders, sync progress.")
-  .action(async () => {
-    try {
-      await status();
-    } catch (err) {
-      ui.error(err instanceof Error ? err.message : String(err));
-      process.exit(1);
-    }
-  });
+  .action(async () => runCommand("status", status));
 
 program
   .command("start")
   .description("Restart botsync daemons without reinitializing.")
-  .action(async () => {
-    try {
-      await start();
-    } catch (err) {
-      ui.error(err instanceof Error ? err.message : String(err));
-      process.exit(1);
-    }
-  });
+  .action(async () => runCommand("start", start));
+
+program
+  .command("doctor")
+  .description("Collect local diagnostics for common botsync failures.")
+  .option("--json", "Emit the diagnostics report as JSON.")
+  .action(async (options: { json?: boolean }) => runCommand("doctor", () => doctor(options)));
 
 program
   .command("update")
   .description("Check for updates and install the latest version.")
-  .action(async () => {
-    try {
-      await update();
-    } catch (err) {
-      ui.error(err instanceof Error ? err.message : String(err));
-      process.exit(1);
-    }
-  });
+  .action(async () => runCommand("update", update));
 
 program
   .command("stop")
   .description("Stop the botsync daemon.")
-  .action(async () => {
-    try {
-      await stop();
-    } catch (err) {
-      ui.error(err instanceof Error ? err.message : String(err));
-      process.exit(1);
-    }
-  });
+  .action(async () => runCommand("stop", stop));
 
 program.parse();

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,0 +1,244 @@
+/**
+ * doctor.ts — The `botsync doctor` command.
+ *
+ * Collects a local diagnostics snapshot for common botsync failure modes.
+ */
+
+import { existsSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+import {
+  CONFIG_FILE,
+  DEFAULT_WEBHOOK_URL,
+  EVENTS_PID_FILE,
+  LOGS_DIR,
+  NETWORK_FILE,
+  PID_FILE,
+  readConfig,
+  readNetworkId,
+  readNetworkSecret,
+} from "../config.js";
+import { isEventsRunning } from "../events.js";
+import { isHeartbeatRunning } from "../heartbeat.js";
+import { readRecentTrace } from "../log.js";
+import { apiCall, getSyncthingBin } from "../syncthing.js";
+import { VERSION } from "../version.js";
+import * as ui from "../ui.js";
+
+interface DoctorCheck {
+  name: string;
+  ok: boolean;
+  detail: string;
+}
+
+interface FolderReport {
+  name: string;
+  state: string;
+  synced: boolean;
+}
+
+interface DoctorReport {
+  version: string;
+  platform: string;
+  node: string;
+  configPath: string;
+  networkPath: string;
+  logsPath: string;
+  checks: DoctorCheck[];
+  folders: FolderReport[];
+  recentIssues: Array<{
+    ts: string;
+    level: string;
+    component: string;
+    message: string;
+    code?: string;
+  }>;
+}
+
+interface FolderStatus {
+  state: string;
+  needFiles: number;
+}
+
+function check(name: string, ok: boolean, detail: string): DoctorCheck {
+  return { name, ok, detail };
+}
+
+async function collectDoctorReport(): Promise<DoctorReport> {
+  const report: DoctorReport = {
+    version: VERSION,
+    platform: `${process.platform}/${process.arch}`,
+    node: process.version,
+    configPath: CONFIG_FILE,
+    networkPath: NETWORK_FILE,
+    logsPath: LOGS_DIR,
+    checks: [],
+    folders: [],
+    recentIssues: readRecentTrace(20).map((entry) => ({
+      ts: entry.ts,
+      level: entry.level,
+      component: entry.component,
+      message: entry.message,
+      ...(entry.code ? { code: entry.code } : {}),
+    })),
+  };
+
+  const config = readConfig();
+  report.checks.push(
+    check("config", !!config, config ? "config.json loaded" : "config.json missing or invalid")
+  );
+
+  const networkId = readNetworkId();
+  const networkSecret = readNetworkSecret();
+  report.checks.push(
+    check(
+      "network",
+      existsSync(NETWORK_FILE),
+      networkId
+        ? `network registered (${networkId.substring(0, 8)}...)`
+        : existsSync(NETWORK_FILE)
+          ? "network file present"
+          : "network.json missing"
+    )
+  );
+  report.checks.push(
+    check(
+      "network-secret",
+      !!networkSecret,
+      networkSecret ? "network secret present" : "network secret missing"
+    )
+  );
+
+  const syncthingBin = getSyncthingBin();
+  report.checks.push(
+    check(
+      "syncthing-binary",
+      existsSync(syncthingBin),
+      existsSync(syncthingBin) ? syncthingBin : `not found (${syncthingBin})`
+    )
+  );
+
+  let syncthingOk = false;
+  if (config) {
+    try {
+      await apiCall("GET", "/rest/system/ping");
+      syncthingOk = true;
+      report.checks.push(
+        check("syncthing-api", true, `reachable on 127.0.0.1:${config.apiPort}`)
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      report.checks.push(check("syncthing-api", false, msg));
+    }
+  } else {
+    report.checks.push(check("syncthing-api", false, "config missing"));
+  }
+
+  report.checks.push(
+    check(
+      "heartbeat",
+      isHeartbeatRunning(),
+      isHeartbeatRunning()
+        ? "heartbeat daemon running"
+        : existsSync(join(LOGS_DIR, "heartbeat.log"))
+          ? "heartbeat daemon not running"
+          : "heartbeat daemon has not started"
+    )
+  );
+
+  const webhookConfigured = !!(process.env.OPENCLAW_HOOKS_TOKEN || config?.webhookToken);
+  const webhookUrl = process.env.OPENCLAW_HOOKS_URL || config?.webhookUrl || DEFAULT_WEBHOOK_URL;
+  report.checks.push(
+    check(
+      "events",
+      webhookConfigured ? isEventsRunning() : true,
+      webhookConfigured
+        ? isEventsRunning()
+          ? `events daemon running (${webhookUrl})`
+          : `webhook configured but events daemon stopped (${webhookUrl})`
+        : "webhook not configured"
+    )
+  );
+
+  report.checks.push(
+    check(
+      "pid-files",
+      existsSync(PID_FILE) || existsSync(EVENTS_PID_FILE),
+      existsSync(PID_FILE) || existsSync(EVENTS_PID_FILE)
+        ? "daemon pid files present"
+        : "no daemon pid files present"
+    )
+  );
+
+  if (syncthingOk) {
+    try {
+      const stConfig = await apiCall<{ folders: Array<{ id: string }> }>("GET", "/rest/config");
+      for (const folder of stConfig.folders.filter((f) => f.id.startsWith("botsync-"))) {
+        try {
+          const status = await apiCall<FolderStatus>("GET", `/rest/db/status?folder=${folder.id}`);
+          report.folders.push({
+            name: folder.id.replace("botsync-", ""),
+            state: status.state,
+            synced: status.state === "idle" && status.needFiles === 0,
+          });
+        } catch {
+          report.folders.push({
+            name: folder.id.replace("botsync-", ""),
+            state: "unknown",
+            synced: false,
+          });
+        }
+      }
+    } catch {
+      // Folder diagnostics are best-effort.
+    }
+  }
+
+  return report;
+}
+
+export async function doctor(options: { json?: boolean } = {}): Promise<void> {
+  const report = await collectDoctorReport();
+  const hasFailures = report.checks.some((item) => !item.ok);
+
+  if (options.json) {
+    console.log(JSON.stringify(report, null, 2));
+    process.exit(hasFailures ? 1 : 0);
+  }
+
+  ui.header();
+  ui.info(`Version: ${report.version}`);
+  ui.info(`Platform: ${report.platform}`);
+  ui.info(`Node: ${report.node}`);
+  ui.info(`Logs: ${report.logsPath.replace(homedir(), "~")}`);
+  ui.gap();
+
+  for (const item of report.checks) {
+    if (item.ok) {
+      ui.stepDone(`${item.name}: ${item.detail}`);
+    } else {
+      ui.stepFail(`${item.name}: ${item.detail}`);
+    }
+  }
+
+  if (report.folders.length > 0) {
+    ui.gap();
+    ui.info("Folders:");
+    for (const folder of report.folders) {
+      ui.info(`  ${folder.name}: ${folder.synced ? "idle" : folder.state}`);
+    }
+  }
+
+  if (report.recentIssues.length > 0) {
+    ui.gap();
+    ui.info("Recent issues:");
+    for (const issue of report.recentIssues.slice(0, 10)) {
+      const code = issue.code ? ` ${issue.code}` : "";
+      ui.info(`  ${issue.ts} [${issue.component}]${code} ${issue.message}`);
+    }
+  }
+
+  ui.gap();
+  process.exit(hasFailures ? 1 : 0);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,6 +36,10 @@ export const CONFIG_FILE = join(BOTSYNC_DIR, "config.json");
 // PID file for the daemon
 export const PID_FILE = join(BOTSYNC_DIR, "daemon.pid");
 
+// Diagnostics and support artifacts
+export const LOGS_DIR = join(BOTSYNC_DIR, "logs");
+export const REPORTS_DIR = join(BOTSYNC_DIR, "reports");
+
 // Sync folders — just shared/ by default. Users can organize within it.
 export const FOLDERS = [
   { id: "botsync-shared", path: join(SYNC_DIR, "shared") },

--- a/src/events-daemon.ts
+++ b/src/events-daemon.ts
@@ -17,10 +17,12 @@ import { readConfig, BOTSYNC_DIR, SYNC_DIR, DEFAULT_WEBHOOK_URL } from "./config
 import { writeFileSync, unlinkSync, statSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
+import { createLogger } from "./log.js";
 
 const PID_FILE = join(BOTSYNC_DIR, "events.pid");
 const DEBOUNCE_MS = 2000;
 const HEALTH_CHECK_INTERVAL_MS = 120_000;
+const logger = createLogger("events");
 
 // Pending file events to batch into a single notification
 let pendingFiles: Array<{ path: string; action: string; size: number }> = [];
@@ -51,7 +53,7 @@ async function sendWebhook(
   body: object
 ): Promise<void> {
   try {
-    await fetch(url, {
+    const res = await fetch(url, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${token}`,
@@ -60,8 +62,15 @@ async function sendWebhook(
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(5000),
     });
+    if (!res.ok) {
+      logger.warn("webhook delivery failed", "BSYNC_EVENTS_WEBHOOK_DELIVERY_FAILED", {
+        status: res.status,
+        url,
+      });
+    }
   } catch {
     // Best-effort — ignore webhook delivery failures
+    logger.warn("webhook delivery failed", "BSYNC_EVENTS_WEBHOOK_DELIVERY_FAILED", { url });
   }
 }
 
@@ -111,6 +120,7 @@ function queueFileEvent(relativePath: string, action: string): void {
     // File may have been deleted or not accessible
   }
   pendingFiles.push({ path: fullPath, action, size });
+  logger.info("queued synced file event", { path: relativePath, action, size });
 
   if (debounceTimer !== null) {
     clearTimeout(debounceTimer);
@@ -208,11 +218,13 @@ async function pollEvents(lastId: number): Promise<number> {
 async function main(): Promise<void> {
   // Require webhook token to be configured — opt-in only
   if (!getWebhookConfig()) {
+    logger.info("events daemon exiting because webhook is not configured");
     process.exit(0);
   }
 
   // Write our PID so stop can kill us
   writeFileSync(PID_FILE, String(process.pid));
+  logger.info("events daemon started", { pid: process.pid });
 
   // Cleanup PID file on exit
   const cleanup = () => {
@@ -229,6 +241,7 @@ async function main(): Promise<void> {
       clearTimeout(debounceTimer);
     }
     await flushFileEvents();
+    logger.info("events daemon stopped", { pid: process.pid });
     cleanup();
     process.exit(0);
   };
@@ -239,6 +252,7 @@ async function main(): Promise<void> {
   setInterval(async () => {
     const alive = await isSyncthingAlive();
     if (!alive) {
+      logger.warn("events daemon exiting because syncthing is unavailable", "BSYNC_SYNCTHING_API_UNREACHABLE");
       cleanup();
       process.exit(0);
     }
@@ -251,4 +265,8 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch(() => process.exit(1));
+main().catch((err) => {
+  const message = err instanceof Error ? err.message : String(err);
+  logger.error("events daemon crashed", "BSYNC_EVENTS_DAEMON_CRASHED", { error: message });
+  process.exit(1);
+});

--- a/src/events.ts
+++ b/src/events.ts
@@ -12,11 +12,17 @@ import { spawn } from "child_process";
 import { readFileSync, existsSync } from "fs";
 import { join, dirname } from "path";
 import { EVENTS_PID_FILE } from "./config.js";
+import { createLogger } from "./log.js";
+
+const logger = createLogger("events");
 
 /** Spawn the events daemon as a detached background process. */
 export function startEvents(): void {
   // Don't double-spawn
-  if (isEventsRunning()) return;
+  if (isEventsRunning()) {
+    logger.info("events daemon already running");
+    return;
+  }
 
   const daemonScript = join(dirname(__filename), "events-daemon.js");
 
@@ -25,6 +31,7 @@ export function startEvents(): void {
     stdio: "ignore",
   });
 
+  logger.info("events daemon spawned", { pid: child.pid });
   child.unref();
 }
 
@@ -34,8 +41,10 @@ export function stopEvents(): void {
   if (pid) {
     try {
       process.kill(pid, "SIGTERM");
+      logger.info("events daemon stopped", { pid });
     } catch {
       // Already dead
+      logger.warn("events daemon stop failed", "BSYNC_EVENTS_DAEMON_STOPPED", { pid });
     }
   }
 }

--- a/src/heartbeat-daemon.ts
+++ b/src/heartbeat-daemon.ts
@@ -13,11 +13,13 @@ import { hostname } from "os";
 import { readConfig, readNetworkId, readNetworkSecret, BOTSYNC_DIR } from "./config.js";
 import { writeFileSync, unlinkSync } from "fs";
 import { join } from "path";
+import { createLogger } from "./log.js";
 
 const RELAY_URL = "https://relay.botsync.io";
 const HEARTBEAT_INTERVAL_MS = 300_000; // 5 minutes — balances liveness with KV write quota
 const HEALTH_CHECK_INTERVAL_MS = 120_000; // Check if Syncthing is alive every 2 min
 const PID_FILE = join(BOTSYNC_DIR, "heartbeat.pid");
+const logger = createLogger("heartbeat");
 
 function getVersion(): string {
   try {
@@ -41,7 +43,10 @@ function getNetworkSecret(): string | null {
 async function sendHeartbeat(): Promise<boolean> {
   const config = readConfig();
   const networkId = readNetworkId();
-  if (!config?.deviceId || !networkId) return false;
+  if (!config?.deviceId || !networkId) {
+    logger.warn("heartbeat skipped due to missing config", "BSYNC_RELAY_HEARTBEAT_FAILED");
+    return false;
+  }
 
   // Build headers — include auth token if available
   const headers: Record<string, string> = {
@@ -70,8 +75,17 @@ async function sendHeartbeat(): Promise<boolean> {
         signal: AbortSignal.timeout(5000),
       }
     );
+    if (!res.ok) {
+      logger.warn("relay heartbeat failed", "BSYNC_RELAY_HEARTBEAT_FAILED", {
+        status: res.status,
+        networkId,
+      });
+    }
     return res.ok;
   } catch {
+    logger.warn("relay heartbeat failed", "BSYNC_RELAY_HEARTBEAT_FAILED", {
+      networkId,
+    });
     return false;
   }
 }
@@ -97,6 +111,7 @@ async function isSyncthingAlive(): Promise<boolean> {
 async function main(): Promise<void> {
   // Write our PID so stop can kill us
   writeFileSync(PID_FILE, String(process.pid));
+  logger.info("heartbeat daemon started", { pid: process.pid });
 
   // Cleanup PID file on exit
   const cleanup = () => {
@@ -106,10 +121,12 @@ async function main(): Promise<void> {
   };
   process.on("exit", cleanup);
   process.on("SIGTERM", () => {
+    logger.info("heartbeat daemon stopped", { pid: process.pid, signal: "SIGTERM" });
     cleanup();
     process.exit(0);
   });
   process.on("SIGINT", () => {
+    logger.info("heartbeat daemon stopped", { pid: process.pid, signal: "SIGINT" });
     cleanup();
     process.exit(0);
   });
@@ -124,10 +141,15 @@ async function main(): Promise<void> {
   setInterval(async () => {
     const alive = await isSyncthingAlive();
     if (!alive) {
+      logger.warn("heartbeat daemon exiting because syncthing is unavailable", "BSYNC_SYNCTHING_API_UNREACHABLE");
       cleanup();
       process.exit(0);
     }
   }, HEALTH_CHECK_INTERVAL_MS);
 }
 
-main().catch(() => process.exit(1));
+main().catch((err) => {
+  const message = err instanceof Error ? err.message : String(err);
+  logger.error("heartbeat daemon crashed", "BSYNC_HEARTBEAT_DAEMON_CRASHED", { error: message });
+  process.exit(1);
+});

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -10,8 +10,10 @@ import { spawn } from "child_process";
 import { readFileSync, existsSync } from "fs";
 import { join, dirname } from "path";
 import { BOTSYNC_DIR } from "./config.js";
+import { createLogger } from "./log.js";
 
 const HEARTBEAT_PID_FILE = join(BOTSYNC_DIR, "heartbeat.pid");
+const logger = createLogger("heartbeat");
 
 /**
  * Spawn the heartbeat daemon as a detached background process.
@@ -23,7 +25,10 @@ const HEARTBEAT_PID_FILE = join(BOTSYNC_DIR, "heartbeat.pid");
  */
 export function startHeartbeat(networkSecret?: string): void {
   // Don't double-spawn
-  if (isHeartbeatRunning()) return;
+  if (isHeartbeatRunning()) {
+    logger.info("heartbeat daemon already running");
+    return;
+  }
 
   const daemonScript = join(dirname(__filename), "heartbeat-daemon.js");
 
@@ -39,6 +44,7 @@ export function startHeartbeat(networkSecret?: string): void {
     env,
   });
 
+  logger.info("heartbeat daemon spawned", { pid: child.pid });
   child.unref();
 }
 
@@ -48,8 +54,10 @@ export function stopHeartbeat(): void {
   if (pid) {
     try {
       process.kill(pid, "SIGTERM");
+      logger.info("heartbeat daemon stopped", { pid });
     } catch {
       // Already dead
+      logger.warn("heartbeat daemon stop failed", "BSYNC_HEARTBEAT_DAEMON_STOPPED", { pid });
     }
   }
 }

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,0 +1,143 @@
+/**
+ * log.ts — Small local diagnostics logger for botsync.
+ *
+ * Writes both per-component text logs and a structured JSONL trace file
+ * under ~/.botsync/logs (inside the sync root's .botsync directory).
+ */
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, unlinkSync } from "fs";
+import { join } from "path";
+import { LOGS_DIR } from "./config.js";
+
+export type LogLevel = "info" | "warn" | "error";
+
+export interface LogEntry {
+  ts: string;
+  level: LogLevel;
+  component: string;
+  message: string;
+  code?: string;
+  data?: Record<string, unknown>;
+}
+
+const TRACE_LOG_FILE = join(LOGS_DIR, "trace.jsonl");
+const MAX_LOG_BYTES = 1024 * 1024;
+const MAX_ROTATED_FILES = 4;
+const REDACT_KEYS = /apikey|authorization|networksecret|webhooktoken|token|secret/i;
+
+function ensureLogsDir(): void {
+  mkdirSync(LOGS_DIR, { recursive: true });
+}
+
+function rotateIfNeeded(path: string): void {
+  try {
+    if (!existsSync(path) || statSync(path).size < MAX_LOG_BYTES) return;
+
+    for (let i = MAX_ROTATED_FILES; i >= 1; i--) {
+      const current = `${path}.${i}`;
+      const next = `${path}.${i + 1}`;
+      if (!existsSync(current)) continue;
+      if (i === MAX_ROTATED_FILES) {
+        unlinkSync(current);
+      } else {
+        renameSync(current, next);
+      }
+    }
+    renameSync(path, `${path}.1`);
+  } catch {
+    // Logging must never break the main command path.
+  }
+}
+
+function redact(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(redact);
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  const input = value as Record<string, unknown>;
+  const output: Record<string, unknown> = {};
+  for (const [key, raw] of Object.entries(input)) {
+    if (REDACT_KEYS.test(key)) {
+      output[key] = "[redacted]";
+    } else {
+      output[key] = redact(raw);
+    }
+  }
+  return output;
+}
+
+function appendLine(path: string, line: string): void {
+  ensureLogsDir();
+  rotateIfNeeded(path);
+  appendFileSync(path, line + "\n", "utf-8");
+}
+
+function formatText(entry: LogEntry): string {
+  const parts = [entry.ts, entry.level.toUpperCase(), `[${entry.component}]`];
+  if (entry.code) parts.push(entry.code);
+  parts.push(entry.message);
+  if (entry.data && Object.keys(entry.data).length > 0) {
+    parts.push(JSON.stringify(entry.data));
+  }
+  return parts.join(" ");
+}
+
+export function log(
+  component: string,
+  level: LogLevel,
+  message: string,
+  options: { code?: string; data?: Record<string, unknown> } = {}
+): void {
+  const entry: LogEntry = {
+    ts: new Date().toISOString(),
+    level,
+    component,
+    message,
+    ...(options.code ? { code: options.code } : {}),
+    ...(options.data ? { data: redact(options.data) as Record<string, unknown> } : {}),
+  };
+
+  try {
+    appendLine(join(LOGS_DIR, `${component}.log`), formatText(entry));
+    appendLine(TRACE_LOG_FILE, JSON.stringify(entry));
+  } catch {
+    // Never throw from logging.
+  }
+}
+
+export function createLogger(component: string) {
+  return {
+    info(message: string, data?: Record<string, unknown>): void {
+      log(component, "info", message, { data });
+    },
+    warn(message: string, code?: string, data?: Record<string, unknown>): void {
+      log(component, "warn", message, { code, data });
+    },
+    error(message: string, code?: string, data?: Record<string, unknown>): void {
+      log(component, "error", message, { code, data });
+    },
+  };
+}
+
+export function readRecentTrace(limit = 20, minLevel: LogLevel = "warn"): LogEntry[] {
+  try {
+    const levels: LogLevel[] = minLevel === "warn" ? ["warn", "error"] : [minLevel];
+    const raw = readFileSync(TRACE_LOG_FILE, "utf-8").trim();
+    if (!raw) return [];
+    return raw
+      .split("\n")
+      .map((line) => JSON.parse(line) as LogEntry)
+      .filter((entry) => levels.includes(entry.level))
+      .slice(-limit)
+      .reverse();
+  } catch {
+    return [];
+  }
+}
+
+export function getTraceLogFile(): string {
+  return TRACE_LOG_FILE;
+}

--- a/src/syncthing.ts
+++ b/src/syncthing.ts
@@ -30,8 +30,10 @@ import {
   FOLDERS,
   readConfig,
 } from "./config.js";
+import { createLogger } from "./log.js";
 
 const SYNCTHING_VERSION = "2.0.15";
+const logger = createLogger("syncthing");
 
 /**
  * Follow redirects for HTTPS GET — needed because GitHub releases
@@ -88,6 +90,7 @@ export async function downloadSyncthing(): Promise<void> {
   // Check if we already have a usable binary (cached or system)
   if (existsSync(SYNCTHING_BIN)) return;
   if (findSystemSyncthing()) {
+    logger.info("using system syncthing binary");
     return; // Using system Syncthing
   }
 
@@ -98,6 +101,7 @@ export async function downloadSyncthing(): Promise<void> {
   // macOS uses .zip, Linux uses .tar.gz
   const ext = process.platform === "darwin" ? "zip" : "tar.gz";
   const url = `https://github.com/syncthing/syncthing/releases/download/v${SYNCTHING_VERSION}/${slug}.${ext}`;
+  logger.info("downloading syncthing binary", { version: SYNCTHING_VERSION, url });
 
   // Download message handled by caller's UI
 
@@ -130,6 +134,7 @@ export async function downloadSyncthing(): Promise<void> {
   }
 
   chmodSync(SYNCTHING_BIN, 0o755);
+  logger.info("syncthing binary ready", { path: SYNCTHING_BIN });
 
   // Clean up the archive
   const { unlinkSync } = await import("fs");
@@ -216,6 +221,7 @@ export function startDaemon(): number {
 
   // Save PID so we can stop it later
   writeFileSync(PID_FILE, pid.toString());
+  logger.info("syncthing daemon started", { pid, bin });
 
   return pid;
 }
@@ -247,6 +253,11 @@ export async function apiCall<T = unknown>(
 
   if (!res.ok) {
     const text = await res.text();
+    logger.warn("syncthing api call failed", "BSYNC_SYNCTHING_API_UNREACHABLE", {
+      method,
+      path,
+      status: res.status,
+    });
     throw new Error(`Syncthing API error: ${res.status} ${text}`);
   }
 
@@ -270,6 +281,7 @@ export async function removeDeprecatedFolders(): Promise<void> {
     for (const folder of config.folders) {
       if (DEPRECATED_FOLDERS.includes(folder.id)) {
         await apiCall("DELETE", `/rest/config/folders/${folder.id}`);
+        logger.info("removed deprecated syncthing folder", { folderId: folder.id });
       }
     }
   } catch {
@@ -361,6 +373,7 @@ export function stopDaemon(): boolean {
     const pid = parseInt(readFileSync(PID_FILE, "utf-8").trim(), 10);
     process.kill(pid, "SIGTERM");
     killed = true;
+    logger.info("syncthing daemon stopped", { pid, source: "pid-file" });
   } catch {
     // PID file missing or process already dead
   }
@@ -369,6 +382,7 @@ export function stopDaemon(): boolean {
   try {
     execSync(`pkill -f "syncthing.*--home=${SYNCTHING_CONFIG_DIR}"`, { stdio: "ignore" });
     killed = true;
+    logger.info("syncthing daemon stopped", { source: "pkill" });
   } catch {
     // No matching process — that's fine
   }
@@ -398,6 +412,7 @@ export function cleanupStale(): void {
     try {
       const pid = parseInt(readFileSync(PID_FILE, "utf-8").trim(), 10);
       process.kill(pid, "SIGTERM");
+      logger.info("cleaned up stale syncthing daemon", { pid, source: "pid-file" });
     } catch {
       // Process already dead — just clean up the file
     }
@@ -414,6 +429,7 @@ export function cleanupStale(): void {
     execSync(`pkill -f "syncthing.*--home=${SYNCTHING_CONFIG_DIR}"`, { stdio: "ignore" });
     // Give it a moment to die
     execSync("sleep 0.5", { stdio: "ignore" });
+    logger.info("cleaned up stale syncthing daemon", { source: "pkill" });
   } catch {
     // No matching process — clean slate
   }


### PR DESCRIPTION
Adds a local diagnostics logger under .botsync/logs plus a new botsync doctor command with human and JSON output. Wires logging into CLI, Syncthing, heartbeat, and events paths for early-stage debugging across machines.