### PR TITLE
feat: `botsync folder` subcommands for custom folder management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-## [0.4.0] - Unreleased (dev)
+## [Unreleased] - dev
+
+### Added
+- **`botsync folder` subcommands** to manage sync folders beyond the default `shared/`:
+  - `folder add <name> [--path] [--type] [--devices]` creates a new folder, creates the local directory if missing, and shares it with paired peers (or a specified subset).
+  - `folder list` shows every botsync-managed folder with its path, type, peer count, and sync state. Marks the default `shared` vs user-added folders.
+  - `folder remove <name> [--force]` unshares locally while keeping the on-disk files (confirmation prompt unless `--force`).
+  - `folder share <name> <deviceId>` / `folder unshare <name> <deviceId>` add or remove a paired peer on an existing folder.
+  - All five commands go through Syncthing's REST API, so stock Syncthing peers can accept the resulting folder shares without a special client.
+- **`src/folders.ts`**: typed API for folder management with validation (rejects slashes, dot-prefixes, reserved names `shared`/`inbox`/`deliverables`/`botsync`), plus 27 vitest unit tests with mocked Syncthing responses.
+
+## [0.4.0]
 
 ### Added
 - **`botsync invite`** — Generate a fresh pairing code to add another machine without reinitializing. Solves the one-time-use code problem.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,134 @@
+# Feature Plan: Custom Folder Management
+
+## Goal
+
+Add first-class CLI commands to create, list, remove, share, and unshare
+arbitrary sync folders on top of the existing single-folder default
+(`botsync-shared`). All operations go through the running Syncthing REST API,
+so stock Syncthing peers can still accept botsync-managed folders with no
+special client on their side.
+
+## Commands
+
+Nested under a new `botsync folder` subcommand (commander supports this cleanly):
+
+| Command                                           | Purpose                                             |
+|---------------------------------------------------|-----------------------------------------------------|
+| `botsync folder add <name> [flags]`               | Create folder, register with Syncthing, share it    |
+| `botsync folder list`                             | Enumerate managed folders + sync state              |
+| `botsync folder remove <name> [--force]`          | Unshare locally, keep files by default              |
+| `botsync folder share <name> <deviceId>`          | Add peer to folder's share list                     |
+| `botsync folder unshare <name> <deviceId>`        | Remove peer from folder's share list                |
+
+### Flags for `add`
+
+- `--path <path>`: where the folder lives on disk. Default: `~/sync/<name>`.
+  Tilde expansion + created if missing.
+- `--type <sendreceive|sendonly|receiveonly>`: default `sendreceive`.
+- `--devices <id1,id2,...>`: comma list. Default: all currently paired peers
+  (every device in Syncthing config other than `myID`).
+
+After success, prints folder ID, path, type, peer count, and copy-paste
+instructions for peers (including stock Syncthing peers) to accept the share.
+
+## Naming rules (`validateFolderName`)
+
+Reject if:
+- empty / whitespace only
+- contains `/`, `\`, or path separators
+- starts with `.`
+- longer than 64 chars
+- not `[a-z0-9][a-z0-9-]*` after lowercasing (keep it simple + filesystem-safe)
+- equals a reserved name: `shared`, `inbox`, `deliverables`, `botsync`, `.botsync`
+  (the first three are current or deprecated defaults; `botsync` / `.botsync`
+  would collide with internal state dirs).
+
+Folder ID convention: `botsync-<name>` to match the existing
+`botsync-shared` pattern. `list` treats any folder whose id starts with
+`botsync-` as managed; `shared` is labelled "default", others are "custom".
+
+## Modules
+
+New files:
+
+- `src/folders.ts` — pure-ish logic layer:
+  - `validateFolderName(name)` → throws on invalid.
+  - `folderIdFor(name)` → `botsync-<name>`.
+  - `nameForFolderId(id)` → strips prefix.
+  - `isDefaultFolder(id)` → id === `botsync-shared`.
+  - `resolveFolderPath(name, override?)` → tilde expansion, absolute path,
+    defaults to `<SYNC_DIR>/<name>`.
+  - `addFolder({ name, path, type, devices })` → calls Syncthing API.
+  - `listFolders()` → returns enriched managed folders + states.
+  - `removeFolder(name)` → DELETE /rest/config/folders/<id>.
+  - `shareFolder(name, deviceId)` → adds to folder's `devices` list.
+  - `unshareFolder(name, deviceId)` → removes from folder's `devices` list.
+  - `getPairedDevices()` → all config devices minus `myID`.
+- `src/commands/folder.ts` — CLI glue for the 5 subcommands. Uses
+  `src/folders.ts` for business logic and `src/ui.ts` for rendering.
+
+Updated files:
+
+- `src/cli.ts` — register `folder` parent command + 5 subcommands.
+- `src/syncthing.ts` — export one small helper (`getFolderConfig(id)`) only if
+  needed; otherwise reuse existing `apiCall` directly from `folders.ts`.
+- `README.md` — new `### Folder Management` section + stock-Syncthing
+  interop note.
+- `CHANGELOG.md` — new `[Unreleased]` entry under a `Folder management`
+  header.
+
+## Tests (vitest, mocked Syncthing API)
+
+`test/folders.test.ts`:
+
+- `validateFolderName` — rejects slashes, reserved names (`shared`,
+  `deliverables`, `inbox`, `botsync`, `.botsync`), empty, too long,
+  uppercase-only, dot-prefixed. Accepts `tera`, `deal-data-2026`, etc.
+- `folderIdFor` / `nameForFolderId` round-trip.
+- `resolveFolderPath` — default, override, tilde expansion, absolute passthrough.
+- `addFolder` — mocked fetch captures PUT payload:
+  - folder id `botsync-<name>`, correct path, type, device list.
+  - rejects reserved names before any API call.
+  - includes own device ID + each peer.
+- `listFolders` — mocked fetch returns mixed folders; only
+  `botsync-*` IDs surface; default vs custom flagged.
+- `removeFolder` — issues DELETE to correct path; errors if folder missing.
+- `shareFolder` / `unshareFolder` — PUT config with devices list mutated;
+  rejects when peer is not in known device list.
+
+`test/cli-folder.test.ts` (optional, thin) — only if there's time; skip if
+covered by `folders.test.ts`.
+
+Mocking pattern: `vi.stubGlobal("fetch", vi.fn())` plus a temp `BOTSYNC_ROOT`
+with a hand-written `config.json` so `apiCall` has an apiKey/port to read.
+The fetch mock routes by method + URL and returns canned JSON.
+
+## Workflow
+
+1. Write PLAN.md (this file)
+2. Write `test/folders.test.ts` (TDD)
+3. Implement `src/folders.ts`
+4. Implement `src/commands/folder.ts`
+5. Register in `src/cli.ts`
+6. `npm test` + `npm run build`
+7. Update README + CHANGELOG
+8. Commit in small, reviewable chunks:
+   - plan
+   - folders module + tests
+   - CLI wiring
+   - docs
+9. Push branch + open PR targeting `dev` (not main)
+
+## Stock Syncthing interop
+
+Explicitly documented in the README. The reason it works:
+
+- botsync-managed folders are plain Syncthing folders. No custom metadata.
+- `botsync folder add --devices <stockDeviceId>` adds a peer just like the
+  Syncthing web UI would.
+- Stock Syncthing peers accept the incoming folder with Syncthing's built-in
+  "accept folder share" flow (or with `autoAcceptFolders` which our own
+  config enables by default).
+
+No special client, no relay involvement beyond initial pairing. We'll call
+this out in README.

--- a/PLAN.md
+++ b/PLAN.md
@@ -51,7 +51,7 @@ Folder ID convention: `botsync-<name>` to match the existing
 
 New files:
 
-- `src/folders.ts` — pure-ish logic layer:
+- `src/folders.ts` - pure-ish logic layer:
   - `validateFolderName(name)` → throws on invalid.
   - `folderIdFor(name)` → `botsync-<name>`.
   - `nameForFolderId(id)` → strips prefix.
@@ -64,39 +64,39 @@ New files:
   - `shareFolder(name, deviceId)` → adds to folder's `devices` list.
   - `unshareFolder(name, deviceId)` → removes from folder's `devices` list.
   - `getPairedDevices()` → all config devices minus `myID`.
-- `src/commands/folder.ts` — CLI glue for the 5 subcommands. Uses
+- `src/commands/folder.ts` - CLI glue for the 5 subcommands. Uses
   `src/folders.ts` for business logic and `src/ui.ts` for rendering.
 
 Updated files:
 
-- `src/cli.ts` — register `folder` parent command + 5 subcommands.
-- `src/syncthing.ts` — export one small helper (`getFolderConfig(id)`) only if
+- `src/cli.ts` - register `folder` parent command + 5 subcommands.
+- `src/syncthing.ts` - export one small helper (`getFolderConfig(id)`) only if
   needed; otherwise reuse existing `apiCall` directly from `folders.ts`.
-- `README.md` — new `### Folder Management` section + stock-Syncthing
+- `README.md` - new `### Folder Management` section + stock-Syncthing
   interop note.
-- `CHANGELOG.md` — new `[Unreleased]` entry under a `Folder management`
+- `CHANGELOG.md` - new `[Unreleased]` entry under a `Folder management`
   header.
 
 ## Tests (vitest, mocked Syncthing API)
 
 `test/folders.test.ts`:
 
-- `validateFolderName` — rejects slashes, reserved names (`shared`,
+- `validateFolderName` - rejects slashes, reserved names (`shared`,
   `deliverables`, `inbox`, `botsync`, `.botsync`), empty, too long,
   uppercase-only, dot-prefixed. Accepts `tera`, `deal-data-2026`, etc.
 - `folderIdFor` / `nameForFolderId` round-trip.
-- `resolveFolderPath` — default, override, tilde expansion, absolute passthrough.
-- `addFolder` — mocked fetch captures PUT payload:
+- `resolveFolderPath` - default, override, tilde expansion, absolute passthrough.
+- `addFolder` - mocked fetch captures PUT payload:
   - folder id `botsync-<name>`, correct path, type, device list.
   - rejects reserved names before any API call.
   - includes own device ID + each peer.
-- `listFolders` — mocked fetch returns mixed folders; only
+- `listFolders` - mocked fetch returns mixed folders; only
   `botsync-*` IDs surface; default vs custom flagged.
-- `removeFolder` — issues DELETE to correct path; errors if folder missing.
-- `shareFolder` / `unshareFolder` — PUT config with devices list mutated;
+- `removeFolder` - issues DELETE to correct path; errors if folder missing.
+- `shareFolder` / `unshareFolder` - PUT config with devices list mutated;
   rejects when peer is not in known device list.
 
-`test/cli-folder.test.ts` (optional, thin) — only if there's time; skip if
+`test/cli-folder.test.ts` (optional, thin) - only if there's time; skip if
 covered by `folders.test.ts`.
 
 Mocking pattern: `vi.stubGlobal("fetch", vi.fn())` plus a temp `BOTSYNC_ROOT`

--- a/README.md
+++ b/README.md
@@ -43,7 +43,46 @@ botsync start             # Restart daemons (after reboot or stop)
 botsync status            # Show sync status and version
 botsync update            # Check for updates and install latest
 botsync stop              # Stop the sync daemon
+botsync folder ...        # Manage custom sync folders (see below)
 ```
+
+### Folder Management
+
+`shared/` is the default folder everyone gets from `botsync init`. For use cases that want an additional isolated namespace (per-project, per-team, or with only a subset of paired machines) use `botsync folder`:
+
+```bash
+# Create a new folder and share it with every paired peer
+botsync folder add tera
+# Or: pick the path, sync mode, and specific peers
+botsync folder add tera --path ~/projects/tera --type sendreceive \
+  --devices <deviceIdA>,<deviceIdB>
+
+# See every managed folder and its sync state
+botsync folder list
+
+# Add or remove a peer on an existing folder without touching the others
+botsync folder share tera <deviceId>
+botsync folder unshare tera <deviceId>
+
+# Remove the folder from local Syncthing (prompts; --force to skip).
+# Local files on disk are kept; only the sync config is removed.
+botsync folder remove tera
+```
+
+**Naming rules.** Folder names are lowercase letters, numbers, and hyphens. The names `shared`, `inbox`, `deliverables`, and `botsync` are reserved and will be rejected. The on-disk folder id Syncthing sees is `botsync-<name>` (so `tera` becomes `botsync-tera`).
+
+**Default behaviour of `folder add`:**
+
+- `--path` defaults to `~/sync/<name>` (created if missing).
+- `--type` defaults to `sendreceive`. Use `sendonly` or `receiveonly` for one-way mirrors.
+- `--devices` defaults to every currently paired peer. Pass a comma-separated list of device IDs to share with only a subset.
+
+**Stock Syncthing interop.** A botsync-managed folder is a plain Syncthing folder. Any peer running vanilla Syncthing can accept the share by:
+
+1. Adding the botsync device's ID as a remote device (Syncthing web UI → Add Remote Device).
+2. Accepting the incoming folder share when Syncthing prompts (or enabling "Auto Accept" on the device).
+
+No botsync client is needed on the peer's side. Botsync only adds the pairing-code flow and the CLI ergonomics on top of Syncthing's normal folder-share machinery.
 
 ## How It Works
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,13 @@ import { start } from "./commands/start.js";
 import { stop } from "./commands/stop.js";
 import { doctor } from "./commands/doctor.js";
 import { update } from "./commands/update.js";
+import {
+  folderAdd,
+  folderList,
+  folderRemove,
+  folderShare,
+  folderUnshare,
+} from "./commands/folder.js";
 import { createLogger } from "./log.js";
 import { VERSION } from "./version.js";
 import * as ui from "./ui.js";
@@ -83,5 +90,58 @@ program
   .command("stop")
   .description("Stop the botsync daemon.")
   .action(async () => runCommand("stop", stop));
+
+// ------------------------------------------------------------------
+// `botsync folder ...` — custom folder management.
+// All subcommands go through the Syncthing REST API so stock Syncthing
+// peers can accept the resulting folder shares with no special client.
+// ------------------------------------------------------------------
+const folder = program
+  .command("folder")
+  .description("Manage custom sync folders (add, list, remove, share).");
+
+folder
+  .command("add <name>")
+  .description("Create a new sync folder and share it with paired peers.")
+  .option("--path <path>", "Local path for the folder (default: ~/sync/<name>)")
+  .option(
+    "--type <type>",
+    "Folder sync mode: sendreceive | sendonly | receiveonly",
+    "sendreceive",
+  )
+  .option(
+    "--devices <ids>",
+    "Comma-separated device IDs to share with (default: all paired peers)",
+  )
+  .action(async (name: string, opts: { path?: string; type?: string; devices?: string }) =>
+    runCommand("folder-add", () => folderAdd(name, opts)),
+  );
+
+folder
+  .command("list")
+  .description("List botsync-managed folders and their sync state.")
+  .action(async () => runCommand("folder-list", () => folderList()));
+
+folder
+  .command("remove <name>")
+  .description("Unshare a folder from local Syncthing (local files are kept).")
+  .option("--force", "Skip the confirmation prompt")
+  .action(async (name: string, opts: { force?: boolean }) =>
+    runCommand("folder-remove", () => folderRemove(name, opts)),
+  );
+
+folder
+  .command("share <name> <deviceId>")
+  .description("Add a paired device to an existing folder's share list.")
+  .action(async (name: string, deviceId: string) =>
+    runCommand("folder-share", () => folderShare(name, deviceId)),
+  );
+
+folder
+  .command("unshare <name> <deviceId>")
+  .description("Remove a device from a folder's share list (still paired).")
+  .action(async (name: string, deviceId: string) =>
+    runCommand("folder-unshare", () => folderUnshare(name, deviceId)),
+  );
 
 program.parse();

--- a/src/commands/folder.ts
+++ b/src/commands/folder.ts
@@ -1,0 +1,220 @@
+/**
+ * folder.ts — The `botsync folder ...` subcommands.
+ *
+ * Thin UX layer on top of src/folders.ts. Handles:
+ *   - botsync folder add <name> [--path] [--type] [--devices]
+ *   - botsync folder list
+ *   - botsync folder remove <name> [--force]
+ *   - botsync folder share <name> <deviceId>
+ *   - botsync folder unshare <name> <deviceId>
+ *
+ * Business logic lives in src/folders.ts. This file only handles input
+ * parsing, confirmation prompts, and rendering.
+ */
+
+import { createInterface } from "readline/promises";
+import chalk from "chalk";
+
+import { apiCall } from "../syncthing.js";
+import {
+  FolderType,
+  VALID_FOLDER_TYPES,
+  addFolder,
+  folderIdFor,
+  getPairedDevices,
+  isDefaultFolder,
+  listFolders,
+  removeFolder,
+  resolveFolderPath,
+  shareFolder,
+  unshareFolder,
+  validateFolderName,
+} from "../folders.js";
+import * as ui from "../ui.js";
+
+/**
+ * Sanity check: every subcommand assumes a running daemon. We surface a
+ * nicer error message than "Syncthing API error: ECONNREFUSED" when it isn't.
+ */
+async function ensureDaemonRunning(): Promise<void> {
+  try {
+    await apiCall("GET", "/rest/system/ping");
+  } catch {
+    throw new Error(
+      "Syncthing daemon is not running. Run `botsync start` first.",
+    );
+  }
+}
+
+/** Simple yes/no prompt. Defaults to no on empty input. */
+async function confirmPrompt(question: string): Promise<boolean> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await rl.question(question);
+    return /^y(es)?$/i.test(answer.trim());
+  } finally {
+    rl.close();
+  }
+}
+
+// ------------------------------------------------------------------------
+// folder add
+// ------------------------------------------------------------------------
+
+export interface AddFolderCliOptions {
+  path?: string;
+  type?: string;
+  devices?: string;
+}
+
+export async function folderAdd(name: string, opts: AddFolderCliOptions): Promise<void> {
+  ui.header();
+  await ensureDaemonRunning();
+
+  // Validate up-front so we fail before any API round-trip on bad input.
+  validateFolderName(name);
+
+  const type = (opts.type || "sendreceive") as FolderType;
+  if (!VALID_FOLDER_TYPES.includes(type)) {
+    throw new Error(
+      `Invalid --type '${opts.type}'. Use one of: ${VALID_FOLDER_TYPES.join(", ")}.`,
+    );
+  }
+
+  const path = resolveFolderPath(name, opts.path);
+
+  // Parse comma-separated --devices list. Empty/undefined means "share with
+  // every paired peer".
+  let devices: string[] | undefined;
+  if (opts.devices && opts.devices.trim().length > 0) {
+    devices = opts.devices
+      .split(",")
+      .map((d) => d.trim())
+      .filter((d) => d.length > 0);
+  }
+
+  const result = await addFolder({
+    name,
+    path,
+    type,
+    devices,
+    // When the user explicitly named peers, reject unknown ones. Default
+    // auto-share is permissive because it's just "every paired peer".
+    strictDevices: devices !== undefined,
+  });
+
+  ui.stepDone(`Folder added: ${chalk.cyan(result.id)}`);
+  ui.info(`Path: ${result.path}`);
+  ui.info(`Type: ${result.type}`);
+  ui.info(`Shared with ${result.deviceCount - 1} peer(s)`);
+  ui.gap();
+
+  // Print peer instructions. This doubles as the stock-Syncthing-interop
+  // story: a peer running vanilla Syncthing just needs to add our device ID
+  // and accept the incoming folder share.
+  if (result.devices.length > 1) {
+    ui.info("Peers will see a pending folder share on their next sync.");
+    ui.info(`They can accept it with:  ${chalk.white(`botsync folder share ${name} <their-device-id>`)}`);
+    ui.info("Stock Syncthing peers accept via the web UI's \"Add Folder\" prompt.");
+  } else {
+    ui.info("No peers paired yet — pair one with `botsync invite`, then:");
+    ui.info(`  ${chalk.white(`botsync folder share ${name} <device-id>`)}`);
+  }
+  ui.gap();
+}
+
+// ------------------------------------------------------------------------
+// folder list
+// ------------------------------------------------------------------------
+
+export async function folderList(): Promise<void> {
+  ui.header();
+  await ensureDaemonRunning();
+
+  const folders = await listFolders();
+
+  if (folders.length === 0) {
+    ui.info("No botsync folders registered.");
+    ui.gap();
+    return;
+  }
+
+  // Keep the rendering minimal. Status is a pair of columns so terminal width
+  // isn't a problem. We group default first, then customs alphabetically.
+  const sorted = [...folders].sort((a, b) => {
+    if (a.isDefault !== b.isDefault) return a.isDefault ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+
+  for (const f of sorted) {
+    const tag = f.isDefault ? chalk.dim("[default]") : chalk.cyan("[custom]");
+    const state = f.synced ? chalk.green("idle") : chalk.yellow(f.state);
+    const name = f.name.padEnd(20);
+    ui.info(`${tag} ${name} ${state}`);
+    ui.info(`         path: ${f.path}`);
+    ui.info(`         type: ${f.type}  peers: ${Math.max(0, f.deviceCount - 1)}`);
+  }
+  ui.gap();
+}
+
+// ------------------------------------------------------------------------
+// folder remove
+// ------------------------------------------------------------------------
+
+export async function folderRemove(name: string, opts: { force?: boolean } = {}): Promise<void> {
+  ui.header();
+  await ensureDaemonRunning();
+
+  const id = folderIdFor(name);
+  if (isDefaultFolder(id)) {
+    throw new Error(
+      "Cannot remove the default 'shared' folder. It is managed by `botsync init`.",
+    );
+  }
+
+  if (!opts.force) {
+    ui.info(`About to unshare folder '${name}' from the local Syncthing.`);
+    ui.info("Local files are kept on disk; only the sync config is removed.");
+    const ok = await confirmPrompt("Continue? [y/N] ");
+    if (!ok) {
+      ui.info("Aborted.");
+      ui.gap();
+      return;
+    }
+  }
+
+  await removeFolder(name);
+  ui.stepDone(`Folder removed: ${id}`);
+  ui.info("Local files were left in place.");
+  ui.gap();
+}
+
+// ------------------------------------------------------------------------
+// folder share / unshare
+// ------------------------------------------------------------------------
+
+export async function folderShare(name: string, deviceId: string): Promise<void> {
+  ui.header();
+  await ensureDaemonRunning();
+  await shareFolder(name, deviceId);
+  ui.stepDone(`Folder '${name}' shared with ${deviceId.substring(0, 7)}...`);
+  ui.gap();
+}
+
+export async function folderUnshare(name: string, deviceId: string): Promise<void> {
+  ui.header();
+  await ensureDaemonRunning();
+  await unshareFolder(name, deviceId);
+  ui.stepDone(`Folder '${name}' no longer shared with ${deviceId.substring(0, 7)}...`);
+  ui.info("The device is still paired. Only this folder was affected.");
+  ui.gap();
+}
+
+// ------------------------------------------------------------------------
+// Helper exposed to the CLI layer for the default-peers hint.
+// ------------------------------------------------------------------------
+
+export async function getPairedPeersSummary(): Promise<{ count: number; ids: string[] }> {
+  const ids = await getPairedDevices();
+  return { count: ids.length, ids };
+}

--- a/src/commands/folder.ts
+++ b/src/commands/folder.ts
@@ -1,5 +1,5 @@
 /**
- * folder.ts — The `botsync folder ...` subcommands.
+ * folder.ts - The `botsync folder ...` subcommands.
  *
  * Thin UX layer on top of src/folders.ts. Handles:
  *   - botsync folder add <name> [--path] [--type] [--devices]
@@ -117,7 +117,7 @@ export async function folderAdd(name: string, opts: AddFolderCliOptions): Promis
     ui.info(`They can accept it with:  ${chalk.white(`botsync folder share ${name} <their-device-id>`)}`);
     ui.info("Stock Syncthing peers accept via the web UI's \"Add Folder\" prompt.");
   } else {
-    ui.info("No peers paired yet — pair one with `botsync invite`, then:");
+    ui.info("No peers paired yet. Pair one with `botsync invite`, then:");
     ui.info(`  ${chalk.white(`botsync folder share ${name} <device-id>`)}`);
   }
   ui.gap();

--- a/src/folders.ts
+++ b/src/folders.ts
@@ -277,11 +277,11 @@ export async function addFolder(opts: AddFolderOptions): Promise<ManagedFolder> 
     devices: deviceIds.map((deviceID) => ({ deviceID })),
   };
 
-  // POST /rest/config/folders — Syncthing accepts PUT or POST here; PUT is
-  // idempotent and matches how we mutate existing folders elsewhere, but for
-  // "create or replace this one folder" Syncthing documents PUT against the
-  // plural endpoint, so that's what we use.
-  await apiCall("PUT", "/rest/config/folders", folder);
+  // POST /rest/config/folders adds a single folder. The plural PUT endpoint
+  // expects an array and would overwrite every folder at once, which is not
+  // what we want. Syncthing documents POST as the "add one" shortcut.
+  // See: https://docs.syncthing.net/rest/config.html#folder-endpoints
+  await apiCall("POST", "/rest/config/folders", folder);
 
   logger.info("folder added", {
     id,

--- a/src/folders.ts
+++ b/src/folders.ts
@@ -1,0 +1,432 @@
+/**
+ * folders.ts — Custom folder management for botsync.
+ *
+ * Thin wrapper around Syncthing's REST API that lets users add, list,
+ * remove, and share additional folders beyond the default `botsync-shared`.
+ *
+ * All folder IDs follow the `botsync-<name>` convention so they are cleanly
+ * separated from any non-botsync folders a user might have set up via the
+ * Syncthing web UI. Everything else is pure Syncthing: stock Syncthing peers
+ * can accept botsync-managed folder shares with no special client support.
+ */
+
+import { mkdirSync } from "fs";
+import { homedir } from "os";
+import { isAbsolute, join, resolve } from "path";
+
+import { SYNC_DIR } from "./config.js";
+import { apiCall, getDeviceId } from "./syncthing.js";
+import { createLogger } from "./log.js";
+
+const logger = createLogger("folders");
+
+/** Every folder id we manage is prefixed with this. */
+export const BOTSYNC_PREFIX = "botsync-";
+
+/** The only folder we ship out of the box. Protected from `folder remove`. */
+export const DEFAULT_FOLDER_NAME = "shared";
+
+/**
+ * Names we refuse to (re)create via `folder add`.
+ * - `shared` is the current default and is created by `botsync init`.
+ * - `inbox` / `deliverables` are deprecated defaults from pre-v0.5.0 that
+ *   the start-up code actively cleans up; re-creating them would reintroduce
+ *   confusion.
+ * - `botsync` / `.botsync` would collide with our internal state directory.
+ */
+const RESERVED_NAMES = new Set([
+  "shared",
+  "inbox",
+  "deliverables",
+  "botsync",
+  ".botsync",
+]);
+
+/** Syncthing folder type values we support. `sendreceive` is the common case. */
+export type FolderType = "sendreceive" | "sendonly" | "receiveonly";
+export const VALID_FOLDER_TYPES: FolderType[] = ["sendreceive", "sendonly", "receiveonly"];
+
+/**
+ * The minimal shape of a Syncthing config response we care about. We keep
+ * the `unknown` passthrough so we can PUT the full config back without
+ * losing fields we don't understand.
+ */
+interface SyncthingFolder {
+  id: string;
+  label?: string;
+  path: string;
+  type: FolderType | string;
+  devices?: Array<{ deviceID: string } & Record<string, unknown>>;
+  [key: string]: unknown;
+}
+
+interface SyncthingDevice {
+  deviceID: string;
+  [key: string]: unknown;
+}
+
+interface SyncthingConfig {
+  devices: SyncthingDevice[];
+  folders: SyncthingFolder[];
+  [key: string]: unknown;
+}
+
+interface FolderStatus {
+  state: string;
+  needFiles: number;
+  globalFiles: number;
+}
+
+/** Public shape returned by `listFolders` — what the CLI renders. */
+export interface ManagedFolder {
+  id: string;
+  name: string;
+  path: string;
+  type: string;
+  deviceCount: number;
+  devices: string[];
+  isDefault: boolean;
+  state: string;
+  synced: boolean;
+}
+
+// ------------------------------------------------------------------------
+// Name / id helpers — pure, no IO. Kept separate for easy unit testing.
+// ------------------------------------------------------------------------
+
+/**
+ * Ensure a user-supplied folder name is safe to use as both a filesystem
+ * directory name and a Syncthing folder id. Throws a human-readable error
+ * on any violation.
+ */
+export function validateFolderName(name: string): void {
+  if (typeof name !== "string" || name.trim().length === 0) {
+    throw new Error("Folder name is required.");
+  }
+
+  const trimmed = name.trim();
+
+  if (trimmed.length > 64) {
+    throw new Error("Folder name must be 64 characters or fewer.");
+  }
+
+  // Slashes / path separators are a hard no: they'd break the on-disk path
+  // assumption and could escape the sync root entirely.
+  if (/[\\/]/.test(trimmed) || trimmed.includes("..")) {
+    throw new Error("Folder name cannot contain slashes or '..' path segments.");
+  }
+
+  // Dot-prefixed names collide with dotfiles (and specifically our own .botsync
+  // internal state directory).
+  if (trimmed.startsWith(".")) {
+    throw new Error("Folder name cannot start with '.'");
+  }
+
+  // Keep it lowercase / filesystem-safe so folder IDs don't shift based on
+  // case-sensitivity differences across platforms.
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(trimmed)) {
+    throw new Error(
+      "Folder name must be lowercase letters, numbers, or hyphens (starting with a letter or number).",
+    );
+  }
+
+  if (RESERVED_NAMES.has(trimmed)) {
+    throw new Error(
+      `'${trimmed}' is a reserved folder name. Pick something else (try 'tera' or 'gpu-fund').`,
+    );
+  }
+}
+
+/** Map `tera` → `botsync-tera`. */
+export function folderIdFor(name: string): string {
+  return `${BOTSYNC_PREFIX}${name}`;
+}
+
+/**
+ * Strip the `botsync-` prefix from a folder id. Returns the raw id if it
+ * was not prefixed (which should only happen for non-botsync folders that
+ * we generally ignore).
+ */
+export function nameForFolderId(id: string): string {
+  return id.startsWith(BOTSYNC_PREFIX) ? id.slice(BOTSYNC_PREFIX.length) : id;
+}
+
+/** Is this the only default folder we ship? */
+export function isDefaultFolder(id: string): boolean {
+  return id === folderIdFor(DEFAULT_FOLDER_NAME);
+}
+
+/**
+ * Turn the user-facing `--path` flag into an absolute path.
+ * - No override → `<SYNC_DIR>/<name>`.
+ * - `~/foo` → `<homedir>/foo` (tilde is not expanded by node automatically).
+ * - Anything else is resolved against the CWD so relative paths still work.
+ */
+export function resolveFolderPath(name: string, override?: string): string {
+  if (!override) return join(SYNC_DIR, name);
+  if (override === "~") return homedir();
+  if (override.startsWith("~/")) return join(homedir(), override.slice(2));
+  if (isAbsolute(override)) return override;
+  return resolve(override);
+}
+
+// ------------------------------------------------------------------------
+// Syncthing config helpers.
+// ------------------------------------------------------------------------
+
+/**
+ * Get the current Syncthing config. We fetch fresh on every mutation so we
+ * don't stomp on concurrent changes from the web UI or another tool.
+ */
+async function getConfig(): Promise<SyncthingConfig> {
+  return apiCall<SyncthingConfig>("GET", "/rest/config");
+}
+
+/**
+ * Read our own device ID. Prefers the cached value in config.json to avoid
+ * an API round-trip; falls back to /rest/system/status if unset.
+ */
+async function getOwnDeviceId(): Promise<string> {
+  const { readConfig } = await import("./config.js");
+  const cfg = readConfig();
+  if (cfg?.deviceId) return cfg.deviceId;
+  return getDeviceId();
+}
+
+/** Return every device known to Syncthing except our own. */
+export async function getPairedDevices(): Promise<string[]> {
+  const config = await getConfig();
+  const myId = await getOwnDeviceId();
+  return config.devices.map((d) => d.deviceID).filter((id) => id !== myId);
+}
+
+// ------------------------------------------------------------------------
+// Mutations.
+// ------------------------------------------------------------------------
+
+export interface AddFolderOptions {
+  name: string;
+  path: string;
+  type: FolderType;
+  /** Explicit peer list. Omit to share with every paired device. */
+  devices?: string[];
+  /** When true, throw if any entry in `devices` is not already paired. */
+  strictDevices?: boolean;
+}
+
+/**
+ * Create a new botsync folder and share it with the given peers.
+ *
+ * - Validates the name and refuses reserved / duplicate ids before hitting
+ *   the API.
+ * - Creates the on-disk path (`mkdir -p`) so Syncthing doesn't complain.
+ * - Always includes our own device in the share list (Syncthing's UI does
+ *   the same; omitting it means Syncthing treats the folder as non-local).
+ */
+export async function addFolder(opts: AddFolderOptions): Promise<ManagedFolder> {
+  validateFolderName(opts.name);
+
+  if (!VALID_FOLDER_TYPES.includes(opts.type)) {
+    throw new Error(
+      `Invalid folder type '${opts.type}'. Use one of: ${VALID_FOLDER_TYPES.join(", ")}.`,
+    );
+  }
+
+  const id = folderIdFor(opts.name);
+
+  const [config, myId] = await Promise.all([getConfig(), getOwnDeviceId()]);
+
+  if (config.folders.some((f) => f.id === id)) {
+    throw new Error(`Folder '${opts.name}' already exists (id: ${id}).`);
+  }
+
+  // Figure out which devices to share with.
+  const knownIds = new Set(config.devices.map((d) => d.deviceID));
+  let targets: string[];
+  if (opts.devices && opts.devices.length > 0) {
+    if (opts.strictDevices) {
+      const unknown = opts.devices.filter((d) => !knownIds.has(d));
+      if (unknown.length > 0) {
+        throw new Error(
+          `Unknown / not paired devices: ${unknown.join(", ")}. Run 'botsync invite' first.`,
+        );
+      }
+    }
+    targets = opts.devices.filter((d) => knownIds.has(d));
+  } else {
+    // Default: share with everyone paired (minus ourselves).
+    targets = config.devices.map((d) => d.deviceID).filter((d) => d !== myId);
+  }
+
+  // Own device must always appear in the share list so Syncthing treats this
+  // as a local folder rather than an external share we're only relaying.
+  const deviceIds = Array.from(new Set([myId, ...targets]));
+
+  // Make sure the directory exists on disk before asking Syncthing to scan it.
+  mkdirSync(opts.path, { recursive: true });
+
+  const folder: SyncthingFolder = {
+    id,
+    label: id,
+    path: opts.path,
+    type: opts.type,
+    // Match the defaults used by `generateConfig` so behaviour is consistent.
+    rescanIntervalS: 10,
+    fsWatcherEnabled: true,
+    fsWatcherDelayS: 1,
+    devices: deviceIds.map((deviceID) => ({ deviceID })),
+  };
+
+  // POST /rest/config/folders — Syncthing accepts PUT or POST here; PUT is
+  // idempotent and matches how we mutate existing folders elsewhere, but for
+  // "create or replace this one folder" Syncthing documents PUT against the
+  // plural endpoint, so that's what we use.
+  await apiCall("PUT", "/rest/config/folders", folder);
+
+  logger.info("folder added", {
+    id,
+    path: opts.path,
+    type: opts.type,
+    deviceCount: deviceIds.length,
+  });
+
+  return {
+    id,
+    name: opts.name,
+    path: opts.path,
+    type: opts.type,
+    deviceCount: deviceIds.length,
+    devices: deviceIds,
+    isDefault: isDefaultFolder(id),
+    state: "unknown",
+    synced: false,
+  };
+}
+
+/**
+ * List every botsync-managed folder with enough metadata to render a CLI
+ * table. Non-botsync folders are intentionally skipped — `botsync status`
+ * only manages our own namespace.
+ */
+export async function listFolders(): Promise<ManagedFolder[]> {
+  const config = await getConfig();
+  const managed = config.folders.filter((f) => f.id.startsWith(BOTSYNC_PREFIX));
+
+  const result: ManagedFolder[] = [];
+  for (const f of managed) {
+    const devices = (f.devices || []).map((d) => d.deviceID);
+    let state = "unknown";
+    let synced = false;
+    try {
+      const s = await apiCall<FolderStatus>(
+        "GET",
+        `/rest/db/status?folder=${encodeURIComponent(f.id)}`,
+      );
+      state = s.state;
+      synced = s.state === "idle" && s.needFiles === 0;
+    } catch {
+      // Folder added but not yet scanned — fall back to unknown.
+    }
+
+    result.push({
+      id: f.id,
+      name: nameForFolderId(f.id),
+      path: f.path,
+      type: String(f.type),
+      deviceCount: devices.length,
+      devices,
+      isDefault: isDefaultFolder(f.id),
+      state,
+      synced,
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Remove a folder from Syncthing config. Does not delete local files — the
+ * on-disk directory is left alone so nothing important gets nuked.
+ *
+ * Refuses to remove the default `shared` folder: that's bootstrapped by
+ * `botsync init` and the start-up flow expects it to exist.
+ */
+export async function removeFolder(name: string): Promise<void> {
+  const id = folderIdFor(name);
+
+  if (isDefaultFolder(id)) {
+    throw new Error(
+      "Cannot remove the default 'shared' folder. It is managed by `botsync init`.",
+    );
+  }
+
+  const config = await getConfig();
+  if (!config.folders.some((f) => f.id === id)) {
+    throw new Error(`Folder '${name}' not found (id: ${id}).`);
+  }
+
+  await apiCall("DELETE", `/rest/config/folders/${encodeURIComponent(id)}`);
+  logger.info("folder removed", { id });
+}
+
+/**
+ * Add a peer device to an existing folder's share list. The peer must
+ * already be paired via `botsync invite` / `botsync join`.
+ */
+export async function shareFolder(name: string, deviceId: string): Promise<void> {
+  // We intentionally keep the device-id shape check loose. Syncthing's real
+  // device ids are 56 chars, but the source of truth is "must already be
+  // paired", which we check below. That check gives a much clearer error
+  // than a format assertion.
+  if (typeof deviceId !== "string" || deviceId.trim().length === 0) {
+    throw new Error("Device id is required.");
+  }
+
+  const id = folderIdFor(name);
+  const config = await getConfig();
+
+  const paired = new Set(config.devices.map((d) => d.deviceID));
+  if (!paired.has(deviceId)) {
+    throw new Error(
+      `Device ${deviceId.substring(0, 7)}... is not paired. Run 'botsync invite' first.`,
+    );
+  }
+
+  const folder = config.folders.find((f) => f.id === id);
+  if (!folder) throw new Error(`Folder '${name}' not found (id: ${id}).`);
+
+  folder.devices = folder.devices || [];
+  if (folder.devices.some((d) => d.deviceID === deviceId)) {
+    // Already shared — no-op.
+    return;
+  }
+  folder.devices.push({ deviceID: deviceId });
+
+  // Round-trip the full config back (same approach used by addDeviceToFolder).
+  await apiCall("PUT", "/rest/config", config);
+  logger.info("folder shared with device", { id, deviceId });
+}
+
+/**
+ * Remove a peer device from an existing folder's share list. Leaves the
+ * device paired at the Syncthing level — this only affects one folder.
+ */
+export async function unshareFolder(name: string, deviceId: string): Promise<void> {
+  const id = folderIdFor(name);
+  const config = await getConfig();
+
+  const folder = config.folders.find((f) => f.id === id);
+  if (!folder) throw new Error(`Folder '${name}' not found (id: ${id}).`);
+
+  const before = folder.devices?.length || 0;
+  folder.devices = (folder.devices || []).filter((d) => d.deviceID !== deviceId);
+  const after = folder.devices.length;
+
+  if (after === before) {
+    // Device wasn't sharing this folder — nothing to do, no API call needed.
+    return;
+  }
+
+  await apiCall("PUT", "/rest/config", config);
+  logger.info("folder unshared from device", { id, deviceId });
+}

--- a/src/folders.ts
+++ b/src/folders.ts
@@ -1,5 +1,5 @@
 /**
- * folders.ts — Custom folder management for botsync.
+ * folders.ts - Custom folder management for botsync.
  *
  * Thin wrapper around Syncthing's REST API that lets users add, list,
  * remove, and share additional folders beyond the default `botsync-shared`.
@@ -77,7 +77,7 @@ interface FolderStatus {
   globalFiles: number;
 }
 
-/** Public shape returned by `listFolders` — what the CLI renders. */
+/** Public shape returned by `listFolders` - what the CLI renders. */
 export interface ManagedFolder {
   id: string;
   name: string;
@@ -91,7 +91,7 @@ export interface ManagedFolder {
 }
 
 // ------------------------------------------------------------------------
-// Name / id helpers — pure, no IO. Kept separate for easy unit testing.
+// Name / id helpers - pure, no IO. Kept separate for easy unit testing.
 // ------------------------------------------------------------------------
 
 /**
@@ -305,7 +305,7 @@ export async function addFolder(opts: AddFolderOptions): Promise<ManagedFolder> 
 
 /**
  * List every botsync-managed folder with enough metadata to render a CLI
- * table. Non-botsync folders are intentionally skipped — `botsync status`
+ * table. Non-botsync folders are intentionally skipped - `botsync status`
  * only manages our own namespace.
  */
 export async function listFolders(): Promise<ManagedFolder[]> {
@@ -325,7 +325,7 @@ export async function listFolders(): Promise<ManagedFolder[]> {
       state = s.state;
       synced = s.state === "idle" && s.needFiles === 0;
     } catch {
-      // Folder added but not yet scanned — fall back to unknown.
+      // Folder added but not yet scanned - fall back to unknown.
     }
 
     result.push({
@@ -345,7 +345,7 @@ export async function listFolders(): Promise<ManagedFolder[]> {
 }
 
 /**
- * Remove a folder from Syncthing config. Does not delete local files — the
+ * Remove a folder from Syncthing config. Does not delete local files - the
  * on-disk directory is left alone so nothing important gets nuked.
  *
  * Refuses to remove the default `shared` folder: that's bootstrapped by
@@ -397,7 +397,7 @@ export async function shareFolder(name: string, deviceId: string): Promise<void>
 
   folder.devices = folder.devices || [];
   if (folder.devices.some((d) => d.deviceID === deviceId)) {
-    // Already shared — no-op.
+    // Already shared - no-op.
     return;
   }
   folder.devices.push({ deviceID: deviceId });
@@ -409,7 +409,7 @@ export async function shareFolder(name: string, deviceId: string): Promise<void>
 
 /**
  * Remove a peer device from an existing folder's share list. Leaves the
- * device paired at the Syncthing level — this only affects one folder.
+ * device paired at the Syncthing level - this only affects one folder.
  */
 export async function unshareFolder(name: string, deviceId: string): Promise<void> {
   const id = folderIdFor(name);
@@ -423,7 +423,7 @@ export async function unshareFolder(name: string, deviceId: string): Promise<voi
   const after = folder.devices.length;
 
   if (after === before) {
-    // Device wasn't sharing this folder — nothing to do, no API call needed.
+    // Device wasn't sharing this folder - nothing to do, no API call needed.
     return;
   }
 

--- a/test/folders.test.ts
+++ b/test/folders.test.ts
@@ -1,5 +1,5 @@
 /**
- * folders.test.ts — Unit tests for custom folder management.
+ * folders.test.ts - Unit tests for custom folder management.
  *
  * All Syncthing API calls are mocked via vi.stubGlobal("fetch"). A temp
  * BOTSYNC_ROOT is used with a hand-written config.json so the apiCall
@@ -162,7 +162,7 @@ describe("addFolder", () => {
   it("creates the folder via PUT /rest/config/folders and shares with peers", async () => {
     const { folders } = await freshModules();
     const { calls } = mockFetch([
-      // Current Syncthing config — one existing folder, one paired peer, plus our own device.
+      // Current Syncthing config - one existing folder, one paired peer, plus our own device.
       {
         match: (m, u) => m === "GET" && u.includes("/rest/config"),
         respond: () => ({
@@ -478,7 +478,7 @@ describe("shareFolder / unshareFolder", () => {
         }),
       },
     ]);
-    // Should not throw — nothing to do, and no PUT is issued.
+    // Should not throw - nothing to do, and no PUT is issued.
     await expect(folders.unshareFolder("tera", "PEER-ABC")).resolves.toBeUndefined();
   });
 });

--- a/test/folders.test.ts
+++ b/test/folders.test.ts
@@ -1,0 +1,507 @@
+/**
+ * folders.test.ts — Unit tests for custom folder management.
+ *
+ * All Syncthing API calls are mocked via vi.stubGlobal("fetch"). A temp
+ * BOTSYNC_ROOT is used with a hand-written config.json so the apiCall
+ * helper finds an apiKey + apiPort without touching the real sync dir.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir, homedir } from "os";
+
+let tmpRoot: string;
+
+/**
+ * Reset module graph + restore globals + create a fresh BOTSYNC_ROOT with a
+ * valid config.json. Needed because config paths are captured at module load
+ * time, so we must re-import after setting the env var.
+ */
+async function freshModules() {
+  vi.resetModules();
+  process.env.BOTSYNC_ROOT = tmpRoot;
+  const cfg = await import("../src/config.js");
+  mkdirSync(cfg.BOTSYNC_DIR, { recursive: true });
+  cfg.writeConfig({ apiKey: "k", apiPort: 12345, deviceId: "MY-DEVICE-ID" });
+  const folders = await import("../src/folders.js");
+  return { cfg, folders };
+}
+
+/**
+ * Build a fetch mock that routes by method + URL substring. The handler is
+ * a list of `{ match, respond }` entries evaluated in order. The first match
+ * wins. Unmatched requests throw so tests fail loudly on unexpected traffic.
+ */
+function mockFetch(handlers: Array<{
+  match: (method: string, url: string, body?: unknown) => boolean;
+  respond: (method: string, url: string, body?: unknown) => { status?: number; body?: unknown };
+}>) {
+  const calls: Array<{ method: string; url: string; body?: unknown }> = [];
+  const impl = vi.fn(async (url: string, init?: RequestInit) => {
+    const method = (init?.method || "GET").toUpperCase();
+    const bodyRaw = init?.body;
+    const body = typeof bodyRaw === "string" && bodyRaw.length > 0 ? JSON.parse(bodyRaw) : undefined;
+    calls.push({ method, url, body });
+
+    for (const h of handlers) {
+      if (h.match(method, url, body)) {
+        const r = h.respond(method, url, body);
+        const status = r.status ?? 200;
+        const respBody = r.body === undefined ? "" : JSON.stringify(r.body);
+        return {
+          ok: status >= 200 && status < 300,
+          status,
+          text: async () => respBody,
+        } as unknown as Response;
+      }
+    }
+    throw new Error(`Unmocked fetch: ${method} ${url}`);
+  });
+  vi.stubGlobal("fetch", impl);
+  return { impl, calls };
+}
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "botsync-folders-"));
+  process.env.BOTSYNC_ROOT = tmpRoot;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  delete process.env.BOTSYNC_ROOT;
+  if (tmpRoot && existsSync(tmpRoot)) {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+describe("validateFolderName", () => {
+  it("accepts simple lowercase names", async () => {
+    const { folders } = await freshModules();
+    expect(() => folders.validateFolderName("tera")).not.toThrow();
+    expect(() => folders.validateFolderName("deal-data-2026")).not.toThrow();
+    expect(() => folders.validateFolderName("gpu123")).not.toThrow();
+  });
+
+  it("rejects empty or whitespace", async () => {
+    const { folders } = await freshModules();
+    expect(() => folders.validateFolderName("")).toThrow();
+    expect(() => folders.validateFolderName("   ")).toThrow();
+  });
+
+  it("rejects slashes and path separators", async () => {
+    const { folders } = await freshModules();
+    expect(() => folders.validateFolderName("foo/bar")).toThrow();
+    expect(() => folders.validateFolderName("foo\\bar")).toThrow();
+    expect(() => folders.validateFolderName("../evil")).toThrow();
+  });
+
+  it("rejects dot-prefixed names", async () => {
+    const { folders } = await freshModules();
+    expect(() => folders.validateFolderName(".secret")).toThrow();
+    expect(() => folders.validateFolderName(".botsync")).toThrow();
+  });
+
+  it("rejects reserved names (current default + deprecated)", async () => {
+    const { folders } = await freshModules();
+    for (const reserved of ["shared", "inbox", "deliverables", "botsync"]) {
+      expect(() => folders.validateFolderName(reserved)).toThrow(/reserved/i);
+    }
+  });
+
+  it("rejects names longer than 64 characters", async () => {
+    const { folders } = await freshModules();
+    expect(() => folders.validateFolderName("a".repeat(65))).toThrow();
+    expect(() => folders.validateFolderName("a".repeat(64))).not.toThrow();
+  });
+
+  it("rejects uppercase and special characters", async () => {
+    const { folders } = await freshModules();
+    expect(() => folders.validateFolderName("TERA")).toThrow();
+    expect(() => folders.validateFolderName("deal space")).toThrow();
+    expect(() => folders.validateFolderName("deal@work")).toThrow();
+  });
+});
+
+describe("folderIdFor / nameForFolderId / isDefaultFolder", () => {
+  it("round-trips the name through the id helpers", async () => {
+    const { folders } = await freshModules();
+    expect(folders.folderIdFor("tera")).toBe("botsync-tera");
+    expect(folders.nameForFolderId("botsync-tera")).toBe("tera");
+  });
+
+  it("marks shared as the default folder", async () => {
+    const { folders } = await freshModules();
+    expect(folders.isDefaultFolder("botsync-shared")).toBe(true);
+    expect(folders.isDefaultFolder("botsync-tera")).toBe(false);
+  });
+});
+
+describe("resolveFolderPath", () => {
+  it("defaults to <SYNC_DIR>/<name>", async () => {
+    const { cfg, folders } = await freshModules();
+    expect(folders.resolveFolderPath("tera")).toBe(join(cfg.SYNC_DIR, "tera"));
+  });
+
+  it("respects an absolute override", async () => {
+    const { folders } = await freshModules();
+    const abs = join(tmpRoot, "somewhere-else");
+    expect(folders.resolveFolderPath("tera", abs)).toBe(abs);
+  });
+
+  it("expands a leading tilde to homedir", async () => {
+    const { folders } = await freshModules();
+    const expanded = folders.resolveFolderPath("tera", "~/custom");
+    expect(expanded.startsWith(homedir())).toBe(true);
+    expect(expanded.endsWith("/custom")).toBe(true);
+  });
+});
+
+describe("addFolder", () => {
+  it("creates the folder via PUT /rest/config/folders and shares with peers", async () => {
+    const { folders } = await freshModules();
+    const { calls } = mockFetch([
+      // Current Syncthing config — one existing folder, one paired peer, plus our own device.
+      {
+        match: (m, u) => m === "GET" && u.includes("/rest/config"),
+        respond: () => ({
+          body: {
+            devices: [
+              { deviceID: "MY-DEVICE-ID" },
+              { deviceID: "PEER-ABC-XYZ" },
+            ],
+            folders: [
+              { id: "botsync-shared", path: "/sync/shared", type: "sendreceive", devices: [] },
+            ],
+          },
+        }),
+      },
+      { match: (m, u) => m === "PUT" && u.includes("/rest/config/folders"), respond: () => ({ body: {} }) },
+    ]);
+
+    const teraPath = join(tmpRoot, "tera");
+    const result = await folders.addFolder({
+      name: "tera",
+      path: teraPath,
+      type: "sendreceive",
+    });
+
+    expect(result.id).toBe("botsync-tera");
+    expect(result.path).toBe(teraPath);
+    expect(result.devices).toContain("PEER-ABC-XYZ");
+    expect(result.devices).toContain("MY-DEVICE-ID");
+
+    // Verify the PUT payload matches what Syncthing expects.
+    const put = calls.find((c) => c.method === "PUT" && c.url.includes("/rest/config/folders"));
+    expect(put).toBeTruthy();
+    const payload = put!.body as {
+      id: string; path: string; type: string; label: string;
+      devices: Array<{ deviceID: string }>;
+    };
+    expect(payload.id).toBe("botsync-tera");
+    expect(payload.path).toBe(teraPath);
+    expect(payload.type).toBe("sendreceive");
+    expect(payload.label).toBe("botsync-tera");
+    const ids = payload.devices.map((d) => d.deviceID).sort();
+    expect(ids).toEqual(["MY-DEVICE-ID", "PEER-ABC-XYZ"].sort());
+  });
+
+  it("rejects reserved names before any API call", async () => {
+    const { folders } = await freshModules();
+    const { impl } = mockFetch([]); // no handlers, any call throws
+    await expect(
+      folders.addFolder({ name: "shared", path: "/tmp/x", type: "sendreceive" }),
+    ).rejects.toThrow(/reserved/i);
+    expect(impl).not.toHaveBeenCalled();
+  });
+
+  it("rejects creating a folder that already exists", async () => {
+    const { folders } = await freshModules();
+    mockFetch([
+      {
+        match: (m, u) => m === "GET" && u.includes("/rest/config"),
+        respond: () => ({
+          body: {
+            devices: [{ deviceID: "MY-DEVICE-ID" }],
+            folders: [{ id: "botsync-tera", path: "/sync/tera", type: "sendreceive", devices: [] }],
+          },
+        }),
+      },
+    ]);
+    await expect(
+      folders.addFolder({ name: "tera", path: "/sync/tera", type: "sendreceive" }),
+    ).rejects.toThrow(/already exists/i);
+  });
+
+  it("honours an explicit --devices list and filters unknown peers", async () => {
+    const { folders } = await freshModules();
+    const { calls } = mockFetch([
+      {
+        match: (m, u) => m === "GET" && u.includes("/rest/config"),
+        respond: () => ({
+          body: {
+            devices: [
+              { deviceID: "MY-DEVICE-ID" },
+              { deviceID: "PEER-ABC" },
+              { deviceID: "PEER-XYZ" },
+            ],
+            folders: [],
+          },
+        }),
+      },
+      { match: (m, u) => m === "PUT", respond: () => ({ body: {} }) },
+    ]);
+
+    await folders.addFolder({
+      name: "tera",
+      path: join(tmpRoot, "tera"),
+      type: "sendreceive",
+      devices: ["PEER-ABC"], // only this one, not PEER-XYZ
+    });
+
+    const put = calls.find((c) => c.method === "PUT" && c.url.includes("/rest/config/folders"));
+    const payload = put!.body as { devices: Array<{ deviceID: string }> };
+    const ids = payload.devices.map((d) => d.deviceID).sort();
+    // Own device always included; PEER-XYZ excluded.
+    expect(ids).toEqual(["MY-DEVICE-ID", "PEER-ABC"].sort());
+  });
+
+  it("throws if the caller passes a device id that is not paired", async () => {
+    const { folders } = await freshModules();
+    mockFetch([
+      {
+        match: (m, u) => m === "GET" && u.includes("/rest/config"),
+        respond: () => ({
+          body: {
+            devices: [{ deviceID: "MY-DEVICE-ID" }, { deviceID: "PEER-ABC" }],
+            folders: [],
+          },
+        }),
+      },
+    ]);
+    await expect(
+      folders.addFolder({
+        name: "tera",
+        path: "/sync/tera",
+        type: "sendreceive",
+        devices: ["PEER-ABC", "UNKNOWN-PEER"],
+        strictDevices: true,
+      }),
+    ).rejects.toThrow(/not paired|unknown/i);
+  });
+
+  it("creates the local directory when it does not exist", async () => {
+    const { folders } = await freshModules();
+    const missingPath = join(tmpRoot, "brand-new-folder");
+    expect(existsSync(missingPath)).toBe(false);
+    mockFetch([
+      {
+        match: (m, u) => m === "GET" && u.includes("/rest/config"),
+        respond: () => ({ body: { devices: [{ deviceID: "MY-DEVICE-ID" }], folders: [] } }),
+      },
+      { match: (m, u) => m === "PUT", respond: () => ({ body: {} }) },
+    ]);
+    await folders.addFolder({ name: "tera", path: missingPath, type: "sendreceive" });
+    expect(existsSync(missingPath)).toBe(true);
+  });
+});
+
+describe("listFolders", () => {
+  it("returns only botsync-* folders with default vs custom flag", async () => {
+    const { folders } = await freshModules();
+    mockFetch([
+      {
+        match: (m, u) => m === "GET" && u.includes("/rest/config"),
+        respond: () => ({
+          body: {
+            devices: [{ deviceID: "MY-DEVICE-ID" }, { deviceID: "PEER-ABC" }],
+            folders: [
+              { id: "botsync-shared", path: "/s/shared", type: "sendreceive", devices: [{ deviceID: "PEER-ABC" }] },
+              { id: "botsync-tera", path: "/s/tera", type: "sendreceive", devices: [{ deviceID: "PEER-ABC" }] },
+              { id: "unrelated-folder", path: "/other", type: "sendreceive", devices: [] },
+            ],
+          },
+        }),
+      },
+      {
+        // Per-folder status endpoint (/rest/db/status?folder=...)
+        match: (m, u) => m === "GET" && u.includes("/rest/db/status"),
+        respond: (_m, u) => ({
+          body: {
+            state: u.includes("botsync-tera") ? "syncing" : "idle",
+            needFiles: u.includes("botsync-tera") ? 3 : 0,
+            globalFiles: 10,
+          },
+        }),
+      },
+    ]);
+
+    const list = await folders.listFolders();
+    expect(list).toHaveLength(2);
+    const ids = list.map((f) => f.id).sort();
+    expect(ids).toEqual(["botsync-shared", "botsync-tera"]);
+
+    const shared = list.find((f) => f.id === "botsync-shared")!;
+    expect(shared.isDefault).toBe(true);
+    expect(shared.deviceCount).toBe(1);
+    expect(shared.synced).toBe(true);
+
+    const tera = list.find((f) => f.id === "botsync-tera")!;
+    expect(tera.isDefault).toBe(false);
+    expect(tera.synced).toBe(false);
+    expect(tera.state).toBe("syncing");
+  });
+});
+
+describe("removeFolder", () => {
+  it("sends DELETE to /rest/config/folders/<id>", async () => {
+    const { folders } = await freshModules();
+    const { calls } = mockFetch([
+      {
+        match: (m, u) => m === "GET" && u.includes("/rest/config"),
+        respond: () => ({
+          body: {
+            devices: [{ deviceID: "MY-DEVICE-ID" }],
+            folders: [{ id: "botsync-tera", path: "/s/tera", type: "sendreceive", devices: [] }],
+          },
+        }),
+      },
+      { match: (m, u) => m === "DELETE", respond: () => ({ body: {} }) },
+    ]);
+
+    await folders.removeFolder("tera");
+    const del = calls.find((c) => c.method === "DELETE");
+    expect(del).toBeTruthy();
+    expect(del!.url).toContain("/rest/config/folders/botsync-tera");
+  });
+
+  it("refuses to remove the default shared folder", async () => {
+    const { folders } = await freshModules();
+    mockFetch([]); // never called
+    await expect(folders.removeFolder("shared")).rejects.toThrow();
+  });
+
+  it("throws if the folder is not registered", async () => {
+    const { folders } = await freshModules();
+    mockFetch([
+      {
+        match: (m, u) => m === "GET" && u.includes("/rest/config"),
+        respond: () => ({
+          body: {
+            devices: [{ deviceID: "MY-DEVICE-ID" }],
+            folders: [],
+          },
+        }),
+      },
+    ]);
+    await expect(folders.removeFolder("tera")).rejects.toThrow(/not found/i);
+  });
+});
+
+describe("shareFolder / unshareFolder", () => {
+  it("shareFolder adds the device to the folder's device list", async () => {
+    const { folders } = await freshModules();
+    const { calls } = mockFetch([
+      {
+        match: (m, u) => m === "GET" && u.includes("/rest/config"),
+        respond: () => ({
+          body: {
+            devices: [{ deviceID: "MY-DEVICE-ID" }, { deviceID: "PEER-NEW" }],
+            folders: [{ id: "botsync-tera", path: "/s/tera", type: "sendreceive", devices: [] }],
+          },
+        }),
+      },
+      { match: (m, u) => m === "PUT" && u.includes("/rest/config"), respond: () => ({ body: {} }) },
+    ]);
+
+    await folders.shareFolder("tera", "PEER-NEW");
+    const put = calls.find((c) => c.method === "PUT");
+    const payload = put!.body as { folders: Array<{ id: string; devices: Array<{ deviceID: string }> }> };
+    const tera = payload.folders.find((f) => f.id === "botsync-tera");
+    expect(tera!.devices.map((d) => d.deviceID)).toContain("PEER-NEW");
+  });
+
+  it("shareFolder rejects peers that are not paired", async () => {
+    const { folders } = await freshModules();
+    mockFetch([
+      {
+        match: (m, u) => m === "GET" && u.includes("/rest/config"),
+        respond: () => ({
+          body: {
+            devices: [{ deviceID: "MY-DEVICE-ID" }],
+            folders: [{ id: "botsync-tera", path: "/s/tera", type: "sendreceive", devices: [] }],
+          },
+        }),
+      },
+    ]);
+    await expect(folders.shareFolder("tera", "STRANGER")).rejects.toThrow(/not paired/i);
+  });
+
+  it("unshareFolder removes the device from the folder", async () => {
+    const { folders } = await freshModules();
+    const { calls } = mockFetch([
+      {
+        match: (m, u) => m === "GET" && u.includes("/rest/config"),
+        respond: () => ({
+          body: {
+            devices: [{ deviceID: "MY-DEVICE-ID" }, { deviceID: "PEER-ABC" }],
+            folders: [{
+              id: "botsync-tera",
+              path: "/s/tera",
+              type: "sendreceive",
+              devices: [{ deviceID: "PEER-ABC" }],
+            }],
+          },
+        }),
+      },
+      { match: (m, u) => m === "PUT", respond: () => ({ body: {} }) },
+    ]);
+
+    await folders.unshareFolder("tera", "PEER-ABC");
+    const put = calls.find((c) => c.method === "PUT");
+    const payload = put!.body as { folders: Array<{ id: string; devices: Array<{ deviceID: string }> }> };
+    const tera = payload.folders.find((f) => f.id === "botsync-tera");
+    expect(tera!.devices.map((d) => d.deviceID)).not.toContain("PEER-ABC");
+  });
+
+  it("unshareFolder is a no-op when the device was not sharing the folder", async () => {
+    const { folders } = await freshModules();
+    mockFetch([
+      {
+        match: (m, u) => m === "GET" && u.includes("/rest/config"),
+        respond: () => ({
+          body: {
+            devices: [{ deviceID: "MY-DEVICE-ID" }, { deviceID: "PEER-ABC" }],
+            folders: [{ id: "botsync-tera", path: "/s/tera", type: "sendreceive", devices: [] }],
+          },
+        }),
+      },
+    ]);
+    // Should not throw — nothing to do, and no PUT is issued.
+    await expect(folders.unshareFolder("tera", "PEER-ABC")).resolves.toBeUndefined();
+  });
+});
+
+describe("getPairedDevices", () => {
+  it("returns every device except our own", async () => {
+    const { folders } = await freshModules();
+    mockFetch([
+      {
+        match: (m, u) => m === "GET" && u.includes("/rest/config"),
+        respond: () => ({
+          body: {
+            devices: [
+              { deviceID: "MY-DEVICE-ID" },
+              { deviceID: "PEER-A" },
+              { deviceID: "PEER-B" },
+            ],
+            folders: [],
+          },
+        }),
+      },
+    ]);
+    const peers = await folders.getPairedDevices();
+    expect(peers.sort()).toEqual(["PEER-A", "PEER-B"]);
+  });
+});

--- a/test/folders.test.ts
+++ b/test/folders.test.ts
@@ -177,7 +177,7 @@ describe("addFolder", () => {
           },
         }),
       },
-      { match: (m, u) => m === "PUT" && u.includes("/rest/config/folders"), respond: () => ({ body: {} }) },
+      { match: (m, u) => m === "POST" && u.includes("/rest/config/folders"), respond: () => ({ body: {} }) },
     ]);
 
     const teraPath = join(tmpRoot, "tera");
@@ -192,8 +192,8 @@ describe("addFolder", () => {
     expect(result.devices).toContain("PEER-ABC-XYZ");
     expect(result.devices).toContain("MY-DEVICE-ID");
 
-    // Verify the PUT payload matches what Syncthing expects.
-    const put = calls.find((c) => c.method === "PUT" && c.url.includes("/rest/config/folders"));
+    // Verify the POST payload matches what Syncthing expects.
+    const put = calls.find((c) => c.method === "POST" && c.url.includes("/rest/config/folders"));
     expect(put).toBeTruthy();
     const payload = put!.body as {
       id: string; path: string; type: string; label: string;
@@ -250,7 +250,7 @@ describe("addFolder", () => {
           },
         }),
       },
-      { match: (m, u) => m === "PUT", respond: () => ({ body: {} }) },
+      { match: (m, u) => m === "POST", respond: () => ({ body: {} }) },
     ]);
 
     await folders.addFolder({
@@ -260,7 +260,7 @@ describe("addFolder", () => {
       devices: ["PEER-ABC"], // only this one, not PEER-XYZ
     });
 
-    const put = calls.find((c) => c.method === "PUT" && c.url.includes("/rest/config/folders"));
+    const put = calls.find((c) => c.method === "POST" && c.url.includes("/rest/config/folders"));
     const payload = put!.body as { devices: Array<{ deviceID: string }> };
     const ids = payload.devices.map((d) => d.deviceID).sort();
     // Own device always included; PEER-XYZ excluded.
@@ -300,7 +300,7 @@ describe("addFolder", () => {
         match: (m, u) => m === "GET" && u.includes("/rest/config"),
         respond: () => ({ body: { devices: [{ deviceID: "MY-DEVICE-ID" }], folders: [] } }),
       },
-      { match: (m, u) => m === "PUT", respond: () => ({ body: {} }) },
+      { match: (m, u) => m === "POST", respond: () => ({ body: {} }) },
     ]);
     await folders.addFolder({ name: "tera", path: missingPath, type: "sendreceive" });
     expect(existsSync(missingPath)).toBe(true);


### PR DESCRIPTION
## Summary

Adds first-class `botsync folder ...` subcommands so users can spin up sync folders beyond the default `shared/` without reaching into the Syncthing web UI. Motivating case: a Tera-only shared folder for collaborating with a subset of paired peers on the GPU compute fund.

Five new commands, all backed by the Syncthing REST API:

```
botsync folder add <name> [--path <path>] [--type sendreceive|sendonly|receiveonly] [--devices <id1,id2,...>]
botsync folder list
botsync folder remove <name> [--force]
botsync folder share <name> <deviceId>
botsync folder unshare <name> <deviceId>
```

## What changed

- `src/folders.ts` - typed API layer: validation, name/id helpers, add/list/remove/share/unshare + getPairedDevices. Folder IDs follow the existing `botsync-<name>` convention.
- `src/commands/folder.ts` - CLI UX layer. Renders friendly output, prompts on destructive actions, surfaces clear errors when the daemon is down or peers aren't paired.
- `src/cli.ts` - registers the nested `folder` parent command and five subcommands via commander.
- `test/folders.test.ts` - 27 vitest unit tests with fetch mocked (no daemon required).
- `README.md` - new `### Folder Management` section plus a Stock Syncthing Interop note explaining how vanilla Syncthing peers accept botsync-managed shares.
- `CHANGELOG.md` - new `[Unreleased]` entry.
- `PLAN.md` - design doc committed alongside the work.

## Naming rules

The validator rejects:
- slashes / backslashes / `..`
- dot-prefixed names (`.secret`, `.botsync`)
- names longer than 64 chars
- uppercase / spaces / special characters
- reserved names: `shared`, `inbox`, `deliverables`, `botsync`

Folder IDs on the wire are `botsync-<name>` so they sit cleanly in their own namespace inside Syncthing.

## Defaults

- `--path`: `~/sync/<name>`, created if missing. Tilde expansion supported.
- `--type`: `sendreceive`. `sendonly` / `receiveonly` available.
- `--devices`: every currently paired peer. Comma-separated list narrows the scope. When the user names peers explicitly, unknown IDs throw instead of being silently dropped.

## Stock Syncthing interop

A botsync-managed folder is a plain Syncthing folder. Any peer running vanilla Syncthing can accept the share by:
1. Adding the botsync device's ID as a remote device.
2. Accepting the incoming folder share (or auto-accepting if configured).

No botsync client required on the peer side. Documented in README.

## Testing

- `npm test` - **68/68 passing** (41 existing + 27 new)
- `npm run build` - clean
- Smoke-tested against the local daemon: `folder add`, `folder list`, `folder remove --force`, plus error paths for reserved names, slashes, unpaired devices, removing `shared`, and unsharing a non-sharing peer. Test folder was created at `/tmp/botsync-smoketest` and cleaned up.

## Checklist

- [x] Feature branched off `dev` (per `CLAUDE.md` git workflow)
- [x] Tests first (TDD), all green
- [x] Build passes
- [x] README + CHANGELOG updated
- [x] No em dashes in new code/docs
- [x] All API calls go through `apiCall` (no spawning `syncthing` directly)
- [x] Heavy comments on business logic, terse on boilerplate
- [x] Stock Syncthing interop explicitly documented
- [ ] Reviewer approval - **Tom to review, please do not auto-merge**

## Demo: once merged, creating the Tera folder

```bash
# On Tom's machine (already paired with Deepak + Euwyn):
npx botsync folder add tera \
  --path ~/sync/tera \
  --devices <deepak-device-id>,<euwyn-device-id>

# Deepak + Euwyn either:
# (a) already running botsync and have auto-accept on - they'll see ~/sync/tera appear automatically, or
# (b) run `botsync folder list` to verify the pending share and accept it via the Syncthing UI.
```

Later, if we add someone to Tera without reinviting:

```bash
npx botsync folder share tera <new-device-id>
```

And to walk someone off without affecting the rest of the network:

```bash
npx botsync folder unshare tera <old-device-id>
```
