### PR TITLE
feat: `botsync id` + default folder path for auto-accept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased] - dev
 
 ### Added
+- **`botsync id`** — Print this machine's full Syncthing device ID on stdout. `botsync status` only shows the first 7 chars for display; pairing (botsync or vanilla Syncthing) needs the full 56-char ID, and previously the only way to get it was grepping `~/sync/.botsync/config.json`. Pipeable: `npx botsync id | pbcopy`.
 - **`botsync folder` subcommands** to manage sync folders beyond the default `shared/`:
   - `folder add <name> [--path] [--type] [--devices]` creates a new folder, creates the local directory if missing, and shares it with paired peers (or a specified subset).
   - `folder list` shows every botsync-managed folder with its path, type, peer count, and sync state. Marks the default `shared` vs user-added folders.
@@ -10,6 +11,9 @@
   - `folder share <name> <deviceId>` / `folder unshare <name> <deviceId>` add or remove a paired peer on an existing folder.
   - All five commands go through Syncthing's REST API, so stock Syncthing peers can accept the resulting folder shares without a special client.
 - **`src/folders.ts`**: typed API for folder management with validation (rejects slashes, dot-prefixes, reserved names `shared`/`inbox`/`deliverables`/`botsync`), plus 27 vitest unit tests with mocked Syncthing responses.
+
+### Changed
+- **Auto-accepted folders land under `~/sync/`.** Added a `<defaults><folder>` block to the generated Syncthing config so any folder shared by a peer (e.g. via `botsync folder share`) auto-accepts at `<sync_root>/<folderID>/` instead of Syncthing's compiled-in default of `~/<folderID>/`. Without this, a peer who hadn't pre-created the folder via `botsync folder add` ended up with files dumped at the wrong path under their home directory. Existing networks are unaffected — the change only takes effect for new `botsync init` runs (or after manually editing `config.xml`).
 
 ## [0.4.0]
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ botsync invite            # Generate a new code to add another machine
 botsync join <passphrase> # Connect to another botsync instance
 botsync start             # Restart daemons (after reboot or stop)
 botsync status            # Show sync status and version
+botsync id                # Print this machine's full Syncthing device ID
 botsync update            # Check for updates and install latest
 botsync stop              # Stop the sync daemon
 botsync folder ...        # Manage custom sync folders (see below)
@@ -79,8 +80,10 @@ botsync folder remove tera
 
 **Stock Syncthing interop.** A botsync-managed folder is a plain Syncthing folder. Any peer running vanilla Syncthing can accept the share by:
 
-1. Adding the botsync device's ID as a remote device (Syncthing web UI → Add Remote Device).
-2. Accepting the incoming folder share when Syncthing prompts (or enabling "Auto Accept" on the device).
+1. Adding the botsync device's ID as a remote device (Syncthing web UI → Add Remote Device). Get the ID with `botsync id` on the botsync side.
+2. The vanilla peer sends back their own device ID (Syncthing web UI → Actions → Show ID).
+3. On the botsync side, run `botsync folder share <name> <vanillaDeviceId>` to add them to the folder.
+4. The vanilla peer accepts the incoming folder share when Syncthing prompts (or enables "Auto Accept" on the device).
 
 No botsync client is needed on the peer's side. Botsync only adds the pairing-code flow and the CLI ergonomics on top of Syncthing's normal folder-share machinery.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "botsync",
-  "version": "0.5.0",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "botsync",
-      "version": "0.5.0",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "base-x": "^4.0.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import { start } from "./commands/start.js";
 import { stop } from "./commands/stop.js";
 import { doctor } from "./commands/doctor.js";
 import { update } from "./commands/update.js";
+import { id } from "./commands/id.js";
 import {
   folderAdd,
   folderList,
@@ -90,6 +91,11 @@ program
   .command("stop")
   .description("Stop the botsync daemon.")
   .action(async () => runCommand("stop", stop));
+
+program
+  .command("id")
+  .description("Print this machine's full Syncthing device ID (for pairing).")
+  .action(async () => runCommand("id", id));
 
 // ------------------------------------------------------------------
 // `botsync folder ...` — custom folder management.

--- a/src/commands/id.ts
+++ b/src/commands/id.ts
@@ -1,0 +1,39 @@
+/**
+ * id.ts — The `botsync id` command.
+ *
+ * Prints this machine's full Syncthing device ID on stdout, with no
+ * formatting or extra output. Pipeable to `pbcopy`, easy to paste into
+ * a chat to share with a peer.
+ *
+ * `botsync status` truncates the device ID to 7 chars for display, which
+ * is fine for a glance but useless when pairing — every Syncthing pairing
+ * (botsync or vanilla) needs the full 56-char ID.
+ */
+
+import { readConfig } from "../config.js";
+import { getDeviceId } from "../syncthing.js";
+import * as ui from "../ui.js";
+
+export async function id(): Promise<void> {
+  const config = readConfig();
+  if (!config) {
+    ui.error("botsync is not initialized. Run `botsync init` first.");
+    process.exit(1);
+  }
+
+  // Prefer the cached value in config.json — avoids hitting the API for
+  // a value that never changes after init. Fall back to the live API in
+  // case config.json predates the deviceId field.
+  if (config.deviceId) {
+    console.log(config.deviceId);
+    return;
+  }
+
+  try {
+    const live = await getDeviceId();
+    console.log(live);
+  } catch {
+    ui.error("Could not read device ID. Is the Syncthing daemon running? Try `botsync start`.");
+    process.exit(1);
+  }
+}

--- a/src/syncthing.ts
+++ b/src/syncthing.ts
@@ -28,6 +28,7 @@ import {
   BOTSYNC_DIR,
   PID_FILE,
   FOLDERS,
+  SYNC_DIR,
   readConfig,
 } from "./config.js";
 import { createLogger } from "./log.js";
@@ -152,6 +153,10 @@ export async function downloadSyncthing(): Promise<void> {
  * - Local discovery enabled: allows finding peers on the same LAN without relay
  * - Relaying disabled: MVP keeps it simple, direct connections only
  * - Random API port: avoids conflicts with other Syncthing instances
+ * - Default folder path: auto-accepted folders land under SYNC_DIR (e.g.
+ *   `~/sync/botsync-tera/`) instead of Syncthing's home-dir default. Without
+ *   this, a peer adding a new folder via `botsync folder add/share` would
+ *   land at `~/<folderID>/` on receivers who hadn't pre-created the folder.
  */
 export function generateConfig(apiKey: string, apiPort: number): string {
   // Build folder XML blocks from our standard folder list
@@ -185,6 +190,11 @@ ${folderXml}
     </options>
 
     <defaults>
+        <folder id="" label="" path="${SYNC_DIR}/%FOLDERID%" type="sendreceive"
+                rescanIntervalS="10" fsWatcherEnabled="true" fsWatcherDelayS="1">
+            <filesystemType>basic</filesystemType>
+            <minDiskFree unit="%">1</minDiskFree>
+        </folder>
         <device>
             <autoAcceptFolders>true</autoAcceptFolders>
         </device>

--- a/test/id.test.ts
+++ b/test/id.test.ts
@@ -1,0 +1,70 @@
+/**
+ * id.test.ts — Tests for the `botsync id` command.
+ *
+ * Verifies that the device ID is printed cleanly to stdout (no formatting,
+ * no extra output) so it pipes into `pbcopy` or shell substitutions.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "botsync-id-"));
+  process.env.BOTSYNC_ROOT = tmpRoot;
+});
+
+afterEach(() => {
+  delete process.env.BOTSYNC_ROOT;
+  if (tmpRoot && existsSync(tmpRoot)) {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+  vi.restoreAllMocks();
+});
+
+describe("botsync id", () => {
+  it("prints the cached device ID and nothing else", async () => {
+    vi.resetModules();
+    process.env.BOTSYNC_ROOT = tmpRoot;
+    const cfg = await import("../src/config.js");
+    cfg.writeConfig({
+      apiKey: "k",
+      apiPort: 1234,
+      deviceId: "GMWDB3G-M6EVYDB-Y3DLJSB-NZAN5JF-PLSSGKQ-BKGRA4V-WTDILQO-KKCHLAX",
+    });
+
+    const logs: string[] = [];
+    const spy = vi.spyOn(console, "log").mockImplementation((...args) => {
+      logs.push(args.join(" "));
+    });
+
+    vi.resetModules();
+    process.env.BOTSYNC_ROOT = tmpRoot;
+    const { id } = await import("../src/commands/id.js");
+    await id();
+
+    spy.mockRestore();
+    expect(logs).toEqual([
+      "GMWDB3G-M6EVYDB-Y3DLJSB-NZAN5JF-PLSSGKQ-BKGRA4V-WTDILQO-KKCHLAX",
+    ]);
+  });
+
+  it("exits with an error when botsync is not initialized", async () => {
+    vi.resetModules();
+    process.env.BOTSYNC_ROOT = tmpRoot;
+
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        throw new Error(`exit:${code}`);
+      }) as never);
+
+    const { id } = await import("../src/commands/id.js");
+    await expect(id()).rejects.toThrow("exit:1");
+
+    exitSpy.mockRestore();
+  });
+});

--- a/test/syncthing.test.ts
+++ b/test/syncthing.test.ts
@@ -34,6 +34,30 @@ describe("generateConfig", () => {
     const xml = generateConfig("key", 9999);
     expect(xml).toContain("<autoAcceptFolders>true</autoAcceptFolders>");
   });
+
+  it("sets a default folder path under SYNC_DIR with %FOLDERID% token", async () => {
+    // Auto-accepted folders should land under our managed sync root, not at
+    // Syncthing's compiled-in default (~/<folderID>/). Otherwise a peer adding
+    // a new folder via `botsync folder share` lands at the wrong path on
+    // anyone who hadn't pre-created it.
+    vi.resetModules();
+    const tmp = mkdtempSync(join(tmpdir(), "botsync-defaults-"));
+    process.env.BOTSYNC_ROOT = tmp;
+    try {
+      const { generateConfig: gen } = await import("../src/syncthing.js");
+      const xml = gen("key", 9999);
+      expect(xml).toContain(`path="${tmp}/%FOLDERID%"`);
+      // The default should be inside a <defaults> block (not the
+      // botsync-shared folder definition above it).
+      const defaultsIdx = xml.indexOf("<defaults>");
+      const tokenIdx = xml.indexOf("%FOLDERID%");
+      expect(defaultsIdx).toBeGreaterThan(-1);
+      expect(tokenIdx).toBeGreaterThan(defaultsIdx);
+    } finally {
+      delete process.env.BOTSYNC_ROOT;
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("cleanupStale", () => {


### PR DESCRIPTION
## Summary

Two small but high-friction gaps surfaced while pairing a real multi-folder network this week (Tom + Deepak + Euwyn for `botsync-tera`):

- **`botsync id`** — prints this machine's full Syncthing device ID on stdout. `botsync status` truncates to 7 chars for display, which is fine for a glance but useless when pairing. Previously the only way to get the full ID was grepping `~/sync/.botsync/config.json`. Pipeable: `npx botsync id | pbcopy`.
- **Default folder path for auto-accept** — added a `<defaults><folder path="<sync_root>/%FOLDERID%">` block to the generated Syncthing config. Without this, auto-accepted folders land at Syncthing's compiled-in default of `~/<folderID>/`, which is *outside* the botsync sync root. Hit this twice in real pairing flows: a peer ran `botsync folder share` against someone who hadn't pre-created the folder via `folder add`, and their files showed up at `~/botsync-tera/` instead of `~/sync/...`. The fix is one XML stanza in `generateConfig`.

Pairs naturally with the new `botsync folder` subcommands on `dev` (#47) — that PR added the share machinery; this PR closes the two UX gaps that became more painful once people start using it.

### Compatibility

Existing networks are unaffected by the default-path change — it only takes effect for new `botsync init` runs (or after a manual `config.xml` edit). No config migration needed.

## Test plan

- [x] `npm run build` — clean, no TS errors
- [x] Smoke-tested `generateConfig()` via `node -e` against a temp `BOTSYNC_ROOT`: emits `<defaults><folder path="<tmp>/%FOLDERID%">` correctly
- [x] Smoke-tested `botsync id` against a written config: prints exactly the deviceId, no formatting; exits with the right error when no config exists
- [ ] CI runs `vitest` on Node 20 (`vitest` doesn't run cleanly on this local Node 20.16 due to a rolldown native-binding mismatch — falls into the [known npm optional-deps bug](https://github.com/npm/cli/issues/4828); GH Actions Node 20 picks up a newer 20.x where it works)
- [ ] After merge to `dev`, manually re-run a `folder add` / `folder share` flow with a peer to confirm the auto-accepted folder lands at `~/sync/<folderID>/` end-to-end

## Notes

- The `%FOLDERID%` token is Syncthing's standard placeholder for the folder's ID in default-path templates.
- Folder IDs keep the `botsync-` prefix (e.g. `~/sync/botsync-tera/`), which is uglier than the bare `~/sync/tera/` you get from manual `folder add`. That inconsistency is intentional and noted: it's the predictable fallback, and users who want clean paths should run `folder add <name>` on both sides before sharing.
- `package-lock.json` change is just a version-bump resync (`0.5.0` → `0.5.3` to match the recent `package.json` bump on main); it was lagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)