### PR TITLE
Add support for network names

### DIFF
--- a/relay/src/index.ts
+++ b/relay/src/index.ts
@@ -65,6 +65,10 @@ interface DeviceInfo {
   version: string; // botsync version
 }
 
+interface NetworkMeta {
+  name: string;
+}
+
 /**
  * Build CORS headers based on the request path.
  *
@@ -124,6 +128,11 @@ function authKey(networkId: string): string {
   return `net:${networkId}:auth`;
 }
 
+/** KV key for dashboard-visible network metadata. */
+function networkMetaKey(networkId: string): string {
+  return `net:${networkId}:meta`;
+}
+
 /** KV key for a device in a network */
 function deviceKey(networkId: string, deviceId: string): string {
   return `net:${networkId}:dev:${deviceId}`;
@@ -132,6 +141,14 @@ function deviceKey(networkId: string, deviceId: string): string {
 /** KV key prefix for listing devices in a network */
 function networkPrefix(networkId: string): string {
   return `net:${networkId}:dev:`;
+}
+
+/** Validate and normalize dashboard-visible network names. */
+function sanitizeNetworkName(input: unknown): string | null {
+  if (typeof input !== "string") return null;
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  return trimmed;
 }
 
 /**
@@ -207,7 +224,7 @@ export default {
     // ── Pairing ──────────────────────────────────────────────
 
     // POST /pair — create a pairing code
-    // Accepts { deviceId, networkId?, networkSecret? }
+    // Accepts { deviceId, networkId?, networkSecret?, networkName? }
     // Relay holds plaintext secret in PAIRS KV for ≤10 min (one-time use, auto-expires)
     if (request.method === "POST" && url.pathname === "/pair") {
       // Rate limit: 10 POST /pair per minute per IP
@@ -223,6 +240,7 @@ export default {
           deviceId?: string;
           networkId?: string;
           networkSecret?: string;
+          networkName?: string;
         };
 
         if (!body.deviceId || typeof body.deviceId !== "string") {
@@ -262,6 +280,7 @@ export default {
         const payload: Record<string, string | null> = {
           deviceId: body.deviceId,
           networkId: body.networkId || null,
+          networkName: sanitizeNetworkName(body.networkName),
         };
 
         // If networkSecret provided, store the hash AND the raw secret.
@@ -320,12 +339,14 @@ export default {
       let deviceId: string;
       let networkId: string | null = null;
       let networkSecret: string | null = null;
+      let networkName: string | null = null;
 
       try {
         const parsed = JSON.parse(raw);
         deviceId = parsed.deviceId;
         networkId = parsed.networkId || null;
         networkSecret = parsed.networkSecret || null;
+        networkName = sanitizeNetworkName(parsed.networkName);
         // Note: secretHash is NOT returned — it's for relay internal use only
       } catch {
         // Old format — raw string is the deviceId
@@ -335,6 +356,9 @@ export default {
       const response: Record<string, string | null> = { deviceId, networkId };
       if (networkSecret) {
         response.networkSecret = networkSecret;
+      }
+      if (networkName) {
+        response.networkName = networkName;
       }
 
       return Response.json(response, { headers: cors });
@@ -365,7 +389,9 @@ export default {
       if (authError) return authError;
 
       try {
-        const body = (await request.json()) as Partial<DeviceInfo>;
+        const body = (await request.json()) as Partial<DeviceInfo> & {
+          networkName?: string;
+        };
 
         if (!body.deviceId || typeof body.deviceId !== "string") {
           return Response.json(
@@ -388,6 +414,14 @@ export default {
         await env.NETWORKS.put(key, JSON.stringify(device), {
           expirationTtl: 600,
         });
+
+        const networkName = sanitizeNetworkName(body.networkName);
+        if (networkName) {
+          const meta: NetworkMeta = {
+            name: networkName,
+          };
+          await env.NETWORKS.put(networkMetaKey(networkId), JSON.stringify(meta));
+        }
 
         return Response.json({ ok: true }, { headers: cors });
       } catch {
@@ -420,6 +454,17 @@ export default {
       const prefix = networkPrefix(networkId);
       const list = await env.NETWORKS.list({ prefix });
       const devices: DeviceInfo[] = [];
+      let networkName: string | null = null;
+
+      const rawMeta = await env.NETWORKS.get(networkMetaKey(networkId));
+      if (rawMeta) {
+        try {
+          const meta = JSON.parse(rawMeta) as Partial<NetworkMeta>;
+          networkName = sanitizeNetworkName(meta.name);
+        } catch {
+          // Ignore corrupt metadata; device list should still render.
+        }
+      }
 
       for (const key of list.keys) {
         const val = await env.NETWORKS.get(key.name);
@@ -439,7 +484,7 @@ export default {
       );
 
       return Response.json(
-        { networkId, devices, count: devices.length },
+        { networkId, networkName, devices, count: devices.length },
         { headers: cors }
       );
     }

--- a/relay/src/index.ts
+++ b/relay/src/index.ts
@@ -69,6 +69,8 @@ interface NetworkMeta {
   name: string;
 }
 
+const MAX_NETWORK_NAME_LENGTH = 64;
+
 /**
  * Build CORS headers based on the request path.
  *
@@ -148,7 +150,7 @@ function sanitizeNetworkName(input: unknown): string | null {
   if (typeof input !== "string") return null;
   const trimmed = input.trim();
   if (!trimmed) return null;
-  return trimmed;
+  return trimmed.slice(0, MAX_NETWORK_NAME_LENGTH);
 }
 
 /**
@@ -417,10 +419,23 @@ export default {
 
         const networkName = sanitizeNetworkName(body.networkName);
         if (networkName) {
-          const meta: NetworkMeta = {
-            name: networkName,
-          };
-          await env.NETWORKS.put(networkMetaKey(networkId), JSON.stringify(meta));
+          const metaKey = networkMetaKey(networkId);
+          const existing = await env.NETWORKS.get(metaKey);
+          let existingName: string | null = null;
+
+          if (existing) {
+            try {
+              const meta = JSON.parse(existing) as Partial<NetworkMeta>;
+              existingName = sanitizeNetworkName(meta.name);
+            } catch {
+              // Rewrite corrupt metadata below.
+            }
+          }
+
+          if (existingName !== networkName) {
+            const meta: NetworkMeta = { name: networkName };
+            await env.NETWORKS.put(metaKey, JSON.stringify(meta));
+          }
         }
 
         return Response.json({ ok: true }, { headers: cors });

--- a/relay/test/integration.test.ts
+++ b/relay/test/integration.test.ts
@@ -118,8 +118,9 @@ describe("Pairing", () => {
     const deviceId = "SECTEST-HIJKLMN-OPQRSTU-VWXYZ12-3456789-0ABCDEF";
     const networkSecret = "my-super-secret-token-12345";
     const networkId = "test-net-secret";
+    const networkName = "team-sync";
 
-    const createRes = await post("/pair", { deviceId, networkId, networkSecret });
+    const createRes = await post("/pair", {deviceId, networkId, networkSecret, networkName});
     expect(createRes.status).toBe(201);
     const { code } = (await createRes.json()) as { code: string };
 
@@ -129,10 +130,12 @@ describe("Pairing", () => {
       deviceId: string;
       networkId: string;
       networkSecret: string;
+      networkName: string;
     };
     expect(json.deviceId).toBe(deviceId);
     expect(json.networkId).toBe(networkId);
     expect(json.networkSecret).toBe(networkSecret);
+    expect(json.networkName).toBe(networkName);
   });
 
   it("11th POST /pair in 60s returns 429 (rate limited)", async () => {
@@ -171,6 +174,7 @@ describe("Auth", () => {
     name: "test-device",
     os: "linux",
     version: "0.3.0",
+    networkName: "test-network",
   };
 
   it("POST /network/:id/heartbeat with Bearer registers auth and returns 200", async () => {
@@ -218,10 +222,12 @@ describe("Auth", () => {
     expect(res.status).toBe(200);
     const json = (await res.json()) as {
       networkId: string;
+      networkName: string;
       devices: Array<{ deviceId: string }>;
       count: number;
     };
     expect(json.networkId).toBe(networkId);
+    expect(json.networkName).toBe("test-network");
     expect(json.count).toBeGreaterThanOrEqual(1);
     expect(json.devices[0].deviceId).toBe("AUTH000"); // truncated to 7 chars
   });
@@ -250,6 +256,7 @@ describe("Legacy compat (no auth set)", () => {
     name: "legacy-device",
     os: "darwin",
     version: "0.2.0",
+    networkName: "legacy-network",
   };
 
   it("POST /network/:id/heartbeat with no Bearer (no auth set) returns 200", async () => {
@@ -264,10 +271,12 @@ describe("Legacy compat (no auth set)", () => {
     expect(res.status).toBe(200);
     const json = (await res.json()) as {
       networkId: string;
+      networkName: string;
       devices: Array<{ deviceId: string }>;
       count: number;
     };
     expect(json.networkId).toBe(networkId);
+    expect(json.networkName).toBe("legacy-network");
     expect(json.count).toBeGreaterThanOrEqual(1);
   });
 });

--- a/relay/test/integration.test.ts
+++ b/relay/test/integration.test.ts
@@ -138,6 +138,20 @@ describe("Pairing", () => {
     expect(json.networkName).toBe(networkName);
   });
 
+  it("truncates networkName in pairing payloads to 64 characters", async () => {
+    const deviceId = "NAMETST-HIJKLMN-OPQRSTU-VWXYZ12-3456789-0ABCDEF";
+    const networkName = "n".repeat(80);
+
+    const createRes = await post("/pair", { deviceId, networkName });
+    expect(createRes.status).toBe(201);
+    const { code } = (await createRes.json()) as { code: string };
+
+    const getRes = await get(`/pair/${code}`);
+    expect(getRes.status).toBe(200);
+    const json = (await getRes.json()) as { networkName: string };
+    expect(json.networkName).toBe("n".repeat(64));
+  });
+
   it("11th POST /pair in 60s returns 429 (rate limited)", async () => {
     // Send 10 requests (the limit)
     const deviceId = "RATELIM-HIJKLMN-OPQRSTU-VWXYZ12-3456789-0ABCDEF";
@@ -230,6 +244,24 @@ describe("Auth", () => {
     expect(json.networkName).toBe("test-network");
     expect(json.count).toBeGreaterThanOrEqual(1);
     expect(json.devices[0].deviceId).toBe("AUTH000"); // truncated to 7 chars
+  });
+
+  it("truncates networkName in heartbeat metadata to 64 characters", async () => {
+    const longNameNetworkId = `long-name-${Date.now()}`;
+    const longNameSecret = "long-name-network-secret";
+    const res = await post(
+      `/network/${longNameNetworkId}/heartbeat`,
+      { ...devicePayload, networkName: "n".repeat(80) },
+      { Authorization: `Bearer ${longNameSecret}` }
+    );
+    expect(res.status).toBe(200);
+
+    const devicesRes = await get(
+      `/network/${longNameNetworkId}/devices?token=${longNameSecret}`
+    );
+    expect(devicesRes.status).toBe(200);
+    const json = (await devicesRes.json()) as { networkName: string };
+    expect(json.networkName).toBe("n".repeat(64));
   });
 
   it("GET /network/:id/devices?token=wrong returns 401", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -54,7 +54,8 @@ program
 program
   .command("init")
   .description("Initialize botsync and start syncing. Prints a passphrase for pairing.")
-  .action(async () => runCommand("init", init));
+  .option("--name <name>", "Human-friendly network name shown on the dashboard.")
+  .action(async (options: { name?: string }) => runCommand("init", () => init(options)));
 
 program
   .command("invite")

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -20,8 +20,10 @@ import {
   SYNCTHING_CONFIG_DIR,
   FOLDERS,
   MANIFEST_FILE,
+  validateNetworkName,
   writeConfig,
   writeNetworkId,
+  writeNetworkName,
   writeNetworkSecret,
   persistWebhookConfig,
 } from "../config.js";
@@ -89,7 +91,11 @@ botsync update   # Update to the latest version
 `;
 }
 
-export async function init(): Promise<void> {
+export interface InitOptions {
+  name?: string;
+}
+
+export async function init(options: InitOptions = {}): Promise<void> {
   ui.header();
 
   // Step 0: Kill any stale Syncthing from a previous interrupted run
@@ -140,11 +146,15 @@ export async function init(): Promise<void> {
   // The relay stores only sha256(secret), never the plaintext.
   const networkId = randomUUID();
   const networkSecret = randomUUID();
+  const networkName = options.name ? validateNetworkName(options.name) : undefined;
   writeNetworkId(networkId);
   writeNetworkSecret(networkSecret);
+  if (networkName) {
+    writeNetworkName(networkName);
+  }
   startHeartbeat(networkSecret);
   startEvents();
-  ui.stepDone("Network registered");
+  ui.stepDone(networkName ? `Network registered (${networkName})` : "Network registered");
 
   // Step 6: Register with relay and display the code
   ui.gap();
@@ -153,6 +163,7 @@ export async function init(): Promise<void> {
     folders: FOLDERS.map((f) => f.id),
     networkId,
     networkSecret,
+    networkName,
   });
 
   if (isRelay) {

--- a/src/commands/invite.ts
+++ b/src/commands/invite.ts
@@ -13,7 +13,13 @@
  * The joining side uses `botsync join <code>` — same as with init.
  */
 
-import { readConfig, readNetworkId, readNetworkSecret, FOLDERS } from "../config.js";
+import {
+  readConfig,
+  readNetworkId,
+  readNetworkName,
+  readNetworkSecret,
+  FOLDERS,
+} from "../config.js";
 import { createCode } from "../passphrase.js";
 import { apiCall } from "../syncthing.js";
 import { waitForNewPeer } from "../peer-discovery.js";
@@ -42,11 +48,13 @@ export async function invite(): Promise<void> {
   // Generate a new pairing code with our existing device ID + network secret
   const networkId = readNetworkId() || undefined;
   const networkSecret = readNetworkSecret() || undefined;
+  const networkName = readNetworkName() || undefined;
   const { code, isRelay } = await createCode({
     deviceId: config.deviceId,
     folders: FOLDERS.map((f) => f.id),
     networkId,
     networkSecret,
+    networkName,
   });
 
   ui.gap();

--- a/src/commands/join.ts
+++ b/src/commands/join.ts
@@ -22,6 +22,7 @@ import {
   writeConfig,
   readConfig,
   writeNetworkId,
+  writeNetworkName,
   writeNetworkSecret,
   persistWebhookConfig,
 } from "../config.js";
@@ -50,12 +51,14 @@ export async function join(passphrase: string): Promise<void> {
   let folders: string[];
   let networkId: string | undefined;
   let networkSecret: string | undefined;
+  let networkName: string | undefined;
   try {
     const data = await resolveCode(passphrase);
     remoteId = data.deviceId;
     folders = data.folders;
     networkId = data.networkId;
     networkSecret = data.networkSecret;
+    networkName = data.networkName;
     spin0.succeed();
   } catch (err) {
     spin0.fail();
@@ -127,9 +130,15 @@ export async function join(passphrase: string): Promise<void> {
     if (networkSecret) {
       writeNetworkSecret(networkSecret);
     }
+    if (networkName) {
+      writeNetworkName(networkName);
+    }
     startHeartbeat(networkSecret);
     startEvents();
     ui.connected(remoteId);
+    if (networkName) {
+      ui.info(`Network: ${networkName}`);
+    }
     ui.info(`Dashboard: https://botsync.io/dashboard#${networkId}`);
   } else {
     ui.connected(remoteId);

--- a/src/config.ts
+++ b/src/config.ts
@@ -72,6 +72,8 @@ interface NetworkFile {
   networkName?: string;
 }
 
+export const MAX_NETWORK_NAME_LENGTH = 64;
+
 /**
  * Persist webhook config from env vars (OPENCLAW_HOOKS_TOKEN, OPENCLAW_HOOKS_URL)
  * into config.json if present and changed. This allows subsequent `botsync start`
@@ -171,7 +173,7 @@ export function validateNetworkName(name: string): string {
   if (!trimmed) {
     throw new Error("Network name cannot be empty.");
   }
-  return trimmed;
+  return trimmed.slice(0, MAX_NETWORK_NAME_LENGTH);
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -48,7 +48,7 @@ export const FOLDERS = [
 // Manifest file — tells agents what this folder is and how to use it
 export const MANIFEST_FILE = join(SYNC_DIR, "BOTSYNC.md");
 
-// Network identity file — stores the network ID for dashboard visibility
+// Network identity file — stores network metadata for dashboard visibility
 export const NETWORK_FILE = join(BOTSYNC_DIR, "network.json");
 
 // PID file for the events daemon
@@ -64,6 +64,12 @@ export interface BotsyncConfig {
   deviceId?: string;
   webhookUrl?: string;   // OpenClaw hooks URL (default: http://127.0.0.1:18789/hooks/agent)
   webhookToken?: string; // OpenClaw hooks bearer token
+}
+
+interface NetworkFile {
+  networkId?: string;
+  networkSecret?: string;
+  networkName?: string;
 }
 
 /**
@@ -153,8 +159,35 @@ export function readNetworkSecret(): string | null {
   return data?.networkSecret || null;
 }
 
+/** Read the human-friendly network name, or return null when unset. */
+export function readNetworkName(): string | null {
+  const data = readNetworkFile();
+  return data?.networkName || null;
+}
+
+/** Validate and normalize a dashboard-visible network name. */
+export function validateNetworkName(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    throw new Error("Network name cannot be empty.");
+  }
+  return trimmed;
+}
+
+/**
+ * Write the human-friendly network name.
+ * SECURITY: Preserve 0o600 because network.json also contains networkSecret.
+ */
+export function writeNetworkName(networkName: string): void {
+  mkdirSync(BOTSYNC_DIR, { recursive: true });
+  const existing = readNetworkFile();
+  const data = { ...existing, networkName: validateNetworkName(networkName) };
+  writeFileSync(NETWORK_FILE, JSON.stringify(data, null, 2));
+  chmodSync(NETWORK_FILE, 0o600);
+}
+
 /** Internal: read the raw network.json file */
-function readNetworkFile(): { networkId?: string; networkSecret?: string } | null {
+function readNetworkFile(): NetworkFile | null {
   try {
     const raw = readFileSync(NETWORK_FILE, "utf-8");
     return JSON.parse(raw);

--- a/src/heartbeat-daemon.ts
+++ b/src/heartbeat-daemon.ts
@@ -10,7 +10,7 @@
  */
 
 import { hostname } from "os";
-import { readConfig, readNetworkId, readNetworkSecret, BOTSYNC_DIR } from "./config.js";
+import { readConfig, readNetworkId, readNetworkName, readNetworkSecret, BOTSYNC_DIR} from "./config.js";
 import { writeFileSync, unlinkSync } from "fs";
 import { join } from "path";
 import { createLogger } from "./log.js";
@@ -71,6 +71,7 @@ async function sendHeartbeat(): Promise<boolean> {
           name: hostname(),
           os: process.platform,
           version: getVersion(),
+          networkName: readNetworkName() || undefined,
         }),
         signal: AbortSignal.timeout(5000),
       }

--- a/src/passphrase.ts
+++ b/src/passphrase.ts
@@ -23,6 +23,7 @@ export interface PassphraseData {
   folders: string[];
   networkId?: string;
   networkSecret?: string;
+  networkName?: string;
 }
 
 /**
@@ -38,6 +39,7 @@ export async function createCode(data: PassphraseData): Promise<{ code: string; 
         deviceId: data.deviceId,
         networkId: data.networkId,
         networkSecret: data.networkSecret,
+        networkName: data.networkName,
       }),
       signal: AbortSignal.timeout(5000),
     });
@@ -83,10 +85,11 @@ export async function resolveCode(code: string): Promise<PassphraseData> {
       }
     }
 
-    const { deviceId, networkId, networkSecret } = (await res.json()) as {
+    const { deviceId, networkId, networkSecret, networkName } = (await res.json()) as {
       deviceId: string;
       networkId?: string;
       networkSecret?: string;
+      networkName?: string;
     };
     // Folders are always the standard set — no need to encode them
     return {
@@ -94,6 +97,7 @@ export async function resolveCode(code: string): Promise<PassphraseData> {
       folders: ["botsync-shared"],
       networkId: networkId || undefined,
       networkSecret: networkSecret || undefined,
+      networkName: networkName || undefined,
     };
   }
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -99,6 +99,40 @@ describe("network secret", () => {
   });
 });
 
+describe("network name", () => {
+  it("returns null when no name exists", async () => {
+    const cfg = await freshImport();
+    expect(cfg.readNetworkName()).toBeNull();
+  });
+
+  it("persists network name to network.json", async () => {
+    const cfg = await freshImport();
+    cfg.writeNetworkName("team-sync");
+    expect(cfg.readNetworkName()).toBe("team-sync");
+  });
+
+  it("trims network name before writing", async () => {
+    const cfg = await freshImport();
+    cfg.writeNetworkName("  team-sync  ");
+    expect(cfg.readNetworkName()).toBe("team-sync");
+  });
+
+  it("rejects empty network names", async () => {
+    const cfg = await freshImport();
+    expect(() => cfg.writeNetworkName("   ")).toThrow("Network name cannot be empty");
+  });
+
+  it("preserves network name when writing ID and secret", async () => {
+    const cfg = await freshImport();
+    cfg.writeNetworkName("team-sync");
+    cfg.writeNetworkId("net-1");
+    cfg.writeNetworkSecret("secret-abc");
+    expect(cfg.readNetworkName()).toBe("team-sync");
+    expect(cfg.readNetworkId()).toBe("net-1");
+    expect(cfg.readNetworkSecret()).toBe("secret-abc");
+  });
+});
+
 describe("BOTSYNC_ROOT override", () => {
   it("uses custom root for all paths", async () => {
     const cfg = await freshImport();

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -117,6 +117,12 @@ describe("network name", () => {
     expect(cfg.readNetworkName()).toBe("team-sync");
   });
 
+  it("caps network names at 64 characters", async () => {
+    const cfg = await freshImport();
+    cfg.writeNetworkName("a".repeat(80));
+    expect(cfg.readNetworkName()).toBe("a".repeat(cfg.MAX_NETWORK_NAME_LENGTH));
+  });
+
   it("rejects empty network names", async () => {
     const cfg = await freshImport();
     expect(() => cfg.writeNetworkName("   ")).toThrow("Network name cannot be empty");

--- a/test/passphrase.test.ts
+++ b/test/passphrase.test.ts
@@ -10,6 +10,7 @@ const SAMPLE_DATA: PassphraseData = {
   folders: ["botsync-shared"],
   networkId: "net-123",
   networkSecret: "secret-456",
+  networkName: "team-sync",
 };
 
 describe("base58 encode/decode (offline mode)", () => {
@@ -85,6 +86,7 @@ describe("resolveCode", () => {
         deviceId: "REMOTE-DEVICE-ID",
         networkId: "net-remote",
         networkSecret: "sec-remote",
+        networkName: "remote-team",
       }),
     });
 
@@ -92,6 +94,7 @@ describe("resolveCode", () => {
     expect(data.deviceId).toBe("REMOTE-DEVICE-ID");
     expect(data.networkId).toBe("net-remote");
     expect(data.networkSecret).toBe("sec-remote");
+    expect(data.networkName).toBe("remote-team");
     expect(data.folders).toEqual(["botsync-shared"]);
   });
 


### PR DESCRIPTION
## Summary

Adds network labels for botsync networks, relates to #14.

Networks were previously identified only by UUIDs. This PR adds a human-friendly network name flow starting at `botsync init --name <name>` and carries that label through local config, pairing, heartbeats, and the relay dashboard API.

- `botsync init --name "team-sync"` — stores `networkName` in local `network.json`
- Pairing payloads now include `networkName`, so joined devices inherit the same label
- Heartbeats now send `networkName` to the relay
- Relay stores network metadata at `net:<networkId>:meta`
- `GET /network/:id/devices` now returns `networkName` alongside devices

This PR adds CLI + relay support. The dashboard UI in `hashbranch/botsync-site` can consume `networkName` in a follow-up.

## Compatibility

Existing networks are unaffected. `networkName` is optional, and older `network.json` files without a name continue to work.

If a network has no name, the relay returns `networkName: null`, so dashboard consumers can fall back to displaying the UUID.

No Syncthing config migration is needed.

## Test plan

- [x] `npm run build` — clean, no TS errors
- [x] `npm test` — root test suite passes on Node 22
- [x] `npm test -- --run test/config.test.ts` — config/network name tests pass
- [x] Verified `botsync init --help` shows `--name <name>`
- [x] Added/updated tests for:
  - `networkName` persistence in `network.json`
  - whitespace trimming and empty-name rejection
  - preserving `networkName` when writing network ID/secret
  - pairing payload create/resolve with `networkName`
  - relay pair/heartbeat/devices response with `networkName`

## Notes

- The production relay must be deployed before cross-machine pairing through `https://relay.botsync.io` can return `networkName`.
- Dashboard rendering requires a follow-up change in `hashbranch/botsync-site`.
